### PR TITLE
Improve profile-based scraping

### DIFF
--- a/MOTEUR/profile_widget.py
+++ b/MOTEUR/profile_widget.py
@@ -12,7 +12,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
 )
 
-from MOTEUR.scraping.profile_manager import ProfileManager
+from MOTEUR.scraping.profile_manager import ProfileManager, Profile
 
 
 class ProfileWidget(QWidget):
@@ -63,7 +63,8 @@ class ProfileWidget(QWidget):
         if current:
             name = current.text()
             self.name_edit.setText(name)
-            css = self.manager.get_profile(name) or ""
+            profile = self.manager.get_profile(name)
+            css = profile.css_selector if profile else ""
             self.css_edit.setText(css)
 
     def add_profile(self) -> None:

--- a/MOTEUR/scraping/profile_manager.py
+++ b/MOTEUR/scraping/profile_manager.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict
+from dataclasses import dataclass
+from typing import Dict, Optional
 
 from .constants import IMAGES_DEFAULT_SELECTOR
+
+
+@dataclass
+class Profile:
+    """Simple container for a scraping profile."""
+
+    css_selector: str
 
 
 class ProfileManager:
@@ -12,7 +20,7 @@ class ProfileManager:
 
     def __init__(self, path: Path | str | None = None) -> None:
         self.path = Path(path) if path is not None else Path(__file__).with_name("profiles.json")
-        self.profiles: Dict[str, str] = {}
+        self.profiles: Dict[str, Profile] = {}
         self.load_profiles()
 
     def load_profiles(self) -> None:
@@ -22,27 +30,34 @@ class ProfileManager:
                 with self.path.open("r", encoding="utf-8") as fh:
                     data = json.load(fh)
                 if isinstance(data, dict):
-                    self.profiles = {str(k): str(v) for k, v in data.items()}
+                    self.profiles = {
+                        str(k): Profile(str(v)) for k, v in data.items()
+                    }
                 else:
                     self.profiles = {}
             except Exception:
                 self.profiles = {}
         else:
-            self.profiles = {"default": IMAGES_DEFAULT_SELECTOR}
+            self.profiles = {"default": Profile(IMAGES_DEFAULT_SELECTOR)}
             self.save_profiles()
 
     def save_profiles(self) -> None:
         """Write current profiles to the JSON file."""
         with self.path.open("w", encoding="utf-8") as fh:
-            json.dump(self.profiles, fh, ensure_ascii=False, indent=2)
+            json.dump(
+                {name: p.css_selector for name, p in self.profiles.items()},
+                fh,
+                ensure_ascii=False,
+                indent=2,
+            )
 
-    def get_profile(self, name: str) -> str | None:
-        """Return the CSS selector for *name* if present."""
+    def get_profile(self, name: str) -> Optional[Profile]:
+        """Return the profile for *name* if present."""
         return self.profiles.get(name)
 
     def add_or_update_profile(self, name: str, css: str) -> None:
         """Add or update *name* with *css* and persist it."""
-        self.profiles[name] = css
+        self.profiles[name] = Profile(css)
         self.save_profiles()
 
     def remove_profile(self, name: str) -> None:

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -10,7 +10,9 @@ def test_default_profile_creation(tmp_path: Path) -> None:
     manager = ProfileManager(json_path)
 
     assert json_path.exists()
-    assert manager.get_profile("default") == IMAGES_DEFAULT_SELECTOR
+    profile = manager.get_profile("default")
+    assert profile is not None
+    assert profile.css_selector == IMAGES_DEFAULT_SELECTOR
 
     with json_path.open() as fh:
         data = json.load(fh)
@@ -24,5 +26,7 @@ def test_add_and_load_profile(tmp_path: Path) -> None:
 
     # Reload from disk
     new_manager = ProfileManager(json_path)
-    assert new_manager.get_profile("amazon") == "img.s-image"
+    profile = new_manager.get_profile("amazon")
+    assert profile is not None
+    assert profile.css_selector == "img.s-image"
     assert "amazon" in new_manager.profiles


### PR DESCRIPTION
## Summary
- introduce `Profile` dataclass in `ProfileManager`
- use profile combo box instead of CSS input in the scraping widget
- look up the CSS selector from the selected profile
- show which profile/selector is used when launching a scrape
- adapt profile widget and tests to new interface

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f04075148330ae231fc613e0b6f0