### PR TITLE
Add profile selection tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,21 @@ Modules prévus (roadmap)
 
  Système de sauvegarde et export CSV/Excel/PDF
 
- Module de scraping (images, descriptions, variantes…)
+Module de scraping (images, descriptions, variantes…)
 
- Tableau de bord avec indicateurs personnalisés
+Tableau de bord avec indicateurs personnalisés
 
- Interface configuration (chemins, utilisateurs, préférences)
+Interface configuration (chemins, utilisateurs, préférences)
+
+## 🧪 Lancer les tests
+
+Après avoir installé les dépendances du projet, les tests unitaires peuvent être
+exécutés avec **pytest**. Depuis la racine du dépôt :
+
+```bash
+PYTHONPATH=. pytest
+```
+
 🔧 Contribution
 Ce projet est en développement actif. Toute idée, retour ou contribution est bienvenue.
 

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -3,6 +3,18 @@ from pathlib import Path
 
 from MOTEUR.scraping.profile_manager import ProfileManager
 from MOTEUR.scraping.constants import IMAGES_DEFAULT_SELECTOR
+from MOTEUR.scraping_widget import ScrapeWorker
+
+
+def _patch_download(monkeypatch):
+    calls = {}
+
+    def fake_download(url: str, *, css_selector: str, **kwargs):
+        calls['css'] = css_selector
+        return {}
+
+    monkeypatch.setattr('MOTEUR.scraping_widget.download_images', fake_download)
+    return calls
 
 
 def test_default_profile_creation(tmp_path: Path) -> None:
@@ -30,3 +42,23 @@ def test_add_and_load_profile(tmp_path: Path) -> None:
     assert profile is not None
     assert profile.css_selector == "img.s-image"
     assert "amazon" in new_manager.profiles
+
+
+def test_scrape_worker_receives_selected_css(monkeypatch) -> None:
+    calls = _patch_download(monkeypatch)
+    worker = ScrapeWorker("http://example.com", "img.test", "folder")
+    worker.run()
+    assert calls['css'] == "img.test"
+
+
+def test_profile_css_used_in_scraper(monkeypatch, tmp_path: Path) -> None:
+    json_path = tmp_path / "profiles.json"
+    manager = ProfileManager(json_path)
+    manager.add_or_update_profile("shop", "div.img")
+
+    calls = _patch_download(monkeypatch)
+    profile = manager.get_profile("shop")
+    assert profile is not None
+    worker = ScrapeWorker("http://example.com", profile.css_selector, "images")
+    worker.run()
+    assert calls['css'] == "div.img"


### PR DESCRIPTION
## Summary
- test that scraping profile selection forwards the right CSS selector
- document how to run the tests in the README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f16ffcec8330a11fbff08ae9f10b