### PR TITLE
Fix line length and unused imports

### DIFF
--- a/MOTEUR/achat_db.py
+++ b/MOTEUR/achat_db.py
@@ -38,7 +38,10 @@ def update_purchase(
     """Update a purchase row identified by *purchase_id*."""
     with sqlite3.connect(db_path) as conn:
         conn.execute(
-            "UPDATE purchases SET date = ?, label = ?, amount = ? WHERE id = ?",
+            (
+                "UPDATE purchases SET date = ?, label = ?, amount = ? "
+                "WHERE id = ?"
+            ),
             (date, label, amount, purchase_id),
         )
         conn.commit()

--- a/MOTEUR/achat_widget.py
+++ b/MOTEUR/achat_widget.py
@@ -71,7 +71,11 @@ class AchatWidget(QWidget):
         layout.addLayout(btn_layout)
 
         self.table = QTableWidget(0, 3)
-        self.table.setHorizontalHeaderLabels(["Date", "Libell\u00e9", "Montant"])
+        self.table.setHorizontalHeaderLabels([
+            "Date",
+            "Libell\u00e9",
+            "Montant",
+        ])
         self.table.verticalHeader().setVisible(False)
         self.table.setSelectionBehavior(QTableWidget.SelectRows)
         self.table.setEditTriggers(QTableWidget.NoEditTriggers)
@@ -93,7 +97,11 @@ class AchatWidget(QWidget):
     def add_purchase(self) -> None:
         label = self.label_edit.text().strip()
         if not label:
-            QMessageBox.warning(self, "Achat", "Veuillez saisir un libell\u00e9")
+            QMessageBox.warning(
+                self,
+                "Achat",
+                "Veuillez saisir un libell\u00e9",
+            )
             return
         date = self.date_edit.date().toString("yyyy-MM-dd")
         amount = self.amount_spin.value()
@@ -104,11 +112,19 @@ class AchatWidget(QWidget):
     def edit_purchase(self) -> None:
         purchase_id = self.get_selected_id()
         if purchase_id is None:
-            QMessageBox.warning(self, "Achat", "S\u00e9lectionnez un achat")
+            QMessageBox.warning(
+                self,
+                "Achat",
+                "S\u00e9lectionnez un achat",
+            )
             return
         label = self.label_edit.text().strip()
         if not label:
-            QMessageBox.warning(self, "Achat", "Veuillez saisir un libell\u00e9")
+            QMessageBox.warning(
+                self,
+                "Achat",
+                "Veuillez saisir un libell\u00e9",
+            )
             return
         date = self.date_edit.date().toString("yyyy-MM-dd")
         amount = self.amount_spin.value()
@@ -126,7 +142,9 @@ class AchatWidget(QWidget):
 
     def load_purchases(self) -> None:
         self.table.setRowCount(0)
-        for purchase_id, date, label, amount in fetch_all_purchases(db_path):
+        for purchase_id, date, label, amount in fetch_all_purchases(
+            db_path
+        ):
             row = self.table.rowCount()
             self.table.insertRow(row)
             item_date = QTableWidgetItem(date)
@@ -141,6 +159,8 @@ class AchatWidget(QWidget):
         item_label = self.table.item(row, 1)
         item_amount = self.table.item(row, 2)
         if item_date and item_label and item_amount:
-            self.date_edit.setDate(QDate.fromString(item_date.text(), "yyyy-MM-dd"))
+            self.date_edit.setDate(
+                QDate.fromString(item_date.text(), "yyyy-MM-dd")
+            )
             self.label_edit.setText(item_label.text())
             self.amount_spin.setValue(float(item_amount.text()))

--- a/MOTEUR/profile_widget.py
+++ b/MOTEUR/profile_widget.py
@@ -13,7 +13,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Signal
 
-from MOTEUR.scraping.profile_manager import ProfileManager, Profile
+from MOTEUR.scraping.profile_manager import ProfileManager
 
 
 class ProfileWidget(QWidget):
@@ -66,7 +66,7 @@ class ProfileWidget(QWidget):
         main_layout.addLayout(btn_layout)
 
     # ------------------------------------------------------------------
-    def profile_selected(self, current, previous) -> None:  # noqa: D401 - Qt API
+    def profile_selected(self, current, previous) -> None:  # noqa: D401
         if current:
             name = current.text()
             self.name_edit.setText(name)
@@ -100,9 +100,11 @@ class ProfileWidget(QWidget):
                 break
         else:
             self.profile_list.addItem(name)
-        self.profile_list.setCurrentRow(
-            [self.profile_list.item(i).text() for i in range(self.profile_list.count())].index(name)
-        )
+        items = [
+            self.profile_list.item(i).text()
+            for i in range(self.profile_list.count())
+        ]
+        self.profile_list.setCurrentRow(items.index(name))
 
     def delete_profile(self) -> None:
         name = self.name_edit.text().strip()
@@ -124,4 +126,3 @@ class ProfileWidget(QWidget):
         name = self.name_edit.text().strip()
         if name:
             self.profile_chosen.emit(name)
-

--- a/MOTEUR/scraping/download_helpers.py
+++ b/MOTEUR/scraping/download_helpers.py
@@ -14,11 +14,15 @@ from .constants import USER_AGENT
 logger = logging.getLogger(__name__)
 
 
-def download_binary(url: str, path: Path, user_agent: str = USER_AGENT) -> None:
+def download_binary(
+    url: str, path: Path, user_agent: str = USER_AGENT
+) -> None:
     """Download binary content from *url* into *path* using *user_agent*."""
     headers = {"User-Agent": user_agent}
     try:
-        with requests.get(url, headers=headers, stream=True, timeout=10) as resp:
+        with requests.get(
+            url, headers=headers, stream=True, timeout=10
+        ) as resp:
             resp.raise_for_status()
             with path.open("wb") as fh:
                 for chunk in resp.iter_content(chunk_size=8192):

--- a/MOTEUR/scraping/image_scraper.py
+++ b/MOTEUR/scraping/image_scraper.py
@@ -19,7 +19,10 @@ from selenium.common.exceptions import TimeoutException
 from tqdm import tqdm
 
 from .driver_utils import setup_driver
-from .constants import IMAGES_DEFAULT_SELECTOR as DEFAULT_CSS_SELECTOR, USER_AGENT
+from .constants import (
+    IMAGES_DEFAULT_SELECTOR as DEFAULT_CSS_SELECTOR,
+    USER_AGENT,
+)
 from . import download_helpers as dl_helpers
 from . import rename_helpers
 
@@ -57,7 +60,11 @@ def _find_product_name(driver) -> str:
     for by, value, attr in selectors:
         try:
             elem = driver.find_element(by, value)
-            text = elem.get_attribute(attr) if attr else getattr(elem, "text", "")
+            text = (
+                elem.get_attribute(attr)
+                if attr
+                else getattr(elem, "text", "")
+            )
             if text:
                 text = text.strip()
             if text:
@@ -82,7 +89,10 @@ def download_images(
     reserved_paths: set[Path] = set()
 
     driver = setup_driver()
-    driver.execute_cdp_cmd("Network.setUserAgentOverride", {"userAgent": user_agent})
+    driver.execute_cdp_cmd(
+        "Network.setUserAgentOverride",
+        {"userAgent": user_agent},
+    )
 
     product_name = ""
     folder = Path()
@@ -115,7 +125,8 @@ def download_images(
 
         img_elements = driver.find_elements(By.CSS_SELECTOR, css_selector)
         logger.info(
-            f"\n\U0001F5BC {len(img_elements)} images trouvées avec le sélecteur : {css_selector}\n"
+            f"\n\U0001F5BC {len(img_elements)} images trouvées avec le "
+            f"sélecteur : {css_selector}\n"
         )
 
         total = len(img_elements)
@@ -157,7 +168,9 @@ def download_images(
                         )
                         futures[fut] = (idx, path)
                 except Exception as exc:
-                    logger.error("\u274c Erreur pour l'image %s : %s", idx, exc)
+                    logger.error(
+                        "\u274c Erreur pour l'image %s : %s", idx, exc
+                    )
             for fut in as_completed(futures):
                 idx, path = futures[fut]
                 try:
@@ -170,7 +183,9 @@ def download_images(
                     if first_image is None:
                         first_image = path
                 except Exception as exc:
-                    logger.error("\u274c Erreur pour l'image %s : %s", idx, exc)
+                    logger.error(
+                        "\u274c Erreur pour l'image %s : %s", idx, exc
+                    )
                     skipped += 1
                 pbar_update(1)
                 done_count += 1

--- a/MOTEUR/scraping/profile_manager.py
+++ b/MOTEUR/scraping/profile_manager.py
@@ -19,7 +19,11 @@ class ProfileManager:
     """Manage scraping profiles stored in a JSON file."""
 
     def __init__(self, path: Path | str | None = None) -> None:
-        self.path = Path(path) if path is not None else Path(__file__).with_name("profiles.json")
+        self.path = (
+            Path(path)
+            if path is not None
+            else Path(__file__).with_name("profiles.json")
+        )
         self.profiles: Dict[str, Profile] = {}
         self.load_profiles()
 

--- a/MOTEUR/scraping/rename_helpers.py
+++ b/MOTEUR/scraping/rename_helpers.py
@@ -43,7 +43,9 @@ def clean_filename(text: str) -> str:
     return ascii_text
 
 
-def rename_with_alt(path: Path, sentences: dict, warned: set[str], reserved: set[Path]) -> Path:
+def rename_with_alt(
+    path: Path, sentences: dict, warned: set[str], reserved: set[Path]
+) -> Path:
     """Rename *path* using ALT sentences if available."""
     product_key = path.parent.name.replace("_", " ")
     phrase_list = sentences.get(product_key)

--- a/MOTEUR/scraping_widget.py
+++ b/MOTEUR/scraping_widget.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import logging
 
-from PySide6.QtCore import Qt, Slot, QObject, Signal, QThread, QUrl
+from PySide6.QtCore import Slot, QObject, Signal, QThread, QUrl
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
     QWidget,
@@ -104,7 +104,8 @@ class ScrapingImagesWidget(QWidget):
         self.folder_edit = QLineEdit()
         self.folder_edit.setPlaceholderText("\ud83d\udcc1 Destination images")
         self.folder_edit.setStyleSheet(
-            "padding: 8px; border-top-left-radius: 6px; border-bottom-left-radius: 6px;"
+            "padding: 8px; border-top-left-radius: 6px;"
+            " border-bottom-left-radius: 6px;"
         )
         folder_layout.addWidget(self.folder_edit)
 
@@ -112,7 +113,8 @@ class ScrapingImagesWidget(QWidget):
         self.browse_btn.setFixedWidth(30)
         self.browse_btn.clicked.connect(self.select_folder)
         self.browse_btn.setStyleSheet(
-            "padding: 6px; border-top-right-radius: 6px; border-bottom-right-radius: 6px;"
+            "padding: 6px; border-top-right-radius: 6px;"
+            " border-bottom-right-radius: 6px;"
         )
         folder_layout.addWidget(self.browse_btn)
 
@@ -209,6 +211,7 @@ class ScrapingImagesWidget(QWidget):
         self.scrape_folder = Path(result.get("folder", ""))
         self.console.append("✅ Terminé")
         if self.scrape_folder and self.scrape_folder.exists():
-            QDesktopServices.openUrl(QUrl.fromLocalFile(str(self.scrape_folder)))
+            QDesktopServices.openUrl(
+                QUrl.fromLocalFile(str(self.scrape_folder))
+            )
         self.start_btn.setEnabled(True)
-

--- a/main.py
+++ b/main.py
@@ -199,7 +199,8 @@ class MainWindow(QMainWindow):
         scrap_section = CollapsibleSection("\ud83d\udee0 Scraping")
 
         self.profiles_btn = SidebarButton(
-            "Profil Scraping", icon_path=str(BASE_DIR / "icons" / "profile.svg")
+            "Profil Scraping",
+            icon_path=str(BASE_DIR / "icons" / "profile.svg"),
         )
         self.profiles_btn.clicked.connect(
             lambda _, b=self.profiles_btn: self.show_profiles(b)
@@ -208,7 +209,8 @@ class MainWindow(QMainWindow):
         self.button_group.append(self.profiles_btn)
 
         self.scrap_img_btn = SidebarButton(
-            "Scraping Images", icon_path=str(BASE_DIR / "icons" / "scraping.svg")
+            "Scraping Images",
+            icon_path=str(BASE_DIR / "icons" / "scraping.svg"),
         )
         self.scrap_img_btn.clicked.connect(
             lambda _, b=self.scrap_img_btn: self.show_scraping_images(b)
@@ -217,7 +219,8 @@ class MainWindow(QMainWindow):
         self.button_group.append(self.scrap_img_btn)
 
         btn = SidebarButton(
-            "Scraping Descriptions", icon_path=str(BASE_DIR / "icons" / "text.svg")
+            "Scraping Descriptions",
+            icon_path=str(BASE_DIR / "icons" / "text.svg"),
         )
         btn.clicked.connect(
             lambda _, b=btn: self.display_content("Scraping : Descriptions", b)

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -14,7 +14,10 @@ def _patch_download(monkeypatch):
         calls['css'] = css_selector
         return {}
 
-    monkeypatch.setattr('MOTEUR.scraping_widget.download_images', fake_download)
+    monkeypatch.setattr(
+        'MOTEUR.scraping_widget.download_images',
+        fake_download,
+    )
     return calls
 
 


### PR DESCRIPTION
## Summary
- remove unused imports in widgets
- wrap long lines across MOTEUR modules and main entry point
- fix trailing newlines
- ensure tests pass

## Testing
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687801cccf4c8330a13017741293211a