### PR TITLE
Improve test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,13 @@ Interface configuration (chemins, utilisateurs, préférences)
 
 ## 🧪 Lancer les tests
 
-Après avoir installé les dépendances du projet, les tests unitaires peuvent être
-exécutés avec **pytest**. Depuis la racine du dépôt :
+Après avoir installé les dépendances du projet avec :
+
+```bash
+pip install -r requirements.txt
+```
+
+les tests unitaires peuvent ensuite être exécutés avec **pytest** depuis la racine du dépôt :
 
 ```bash
 PYTHONPATH=. pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+flake8
+pytest


### PR DESCRIPTION
## Summary
- clarify that dependencies must be installed before running tests
- add a requirements-dev.txt for contributor tools

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687803dccd208330a1f2846d20995eab