### PR TITLE
Add configurable dashboard indicators

### DIFF
--- a/MOTEUR/dashboard_config.json
+++ b/MOTEUR/dashboard_config.json
@@ -1,0 +1,6 @@
+{
+  "show_total_count": true,
+  "show_total_amount": true,
+  "show_avg_per_month": true,
+  "show_chart": true
+}

--- a/MOTEUR/dashboard_widget.py
+++ b/MOTEUR/dashboard_widget.py
@@ -4,15 +4,31 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+import json
 
-from PySide6.QtCore import Slot
-from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+from PySide6.QtCore import Slot, Signal
+from PySide6.QtWidgets import (
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+    QCheckBox,
+    QHBoxLayout,
+    QPushButton,
+)
 
 from .achat_db import fetch_all_purchases, init_db
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 # Default path to the SQLite database used in AchatWidget
 DB_PATH = BASE_DIR / "compta.db"
+CONFIG_PATH = Path(__file__).with_name("dashboard_config.json")
+
+DEFAULT_CONFIG = {
+    "show_total_count": True,
+    "show_total_amount": True,
+    "show_avg_per_month": True,
+    "show_chart": True,
+}
 
 try:
     import matplotlib
@@ -26,14 +42,66 @@ except Exception:  # pragma: no cover - matplotlib is optional
     MPL_AVAILABLE = False
 
 
+def load_dashboard_config() -> dict:
+    """Return dashboard configuration from :data:`CONFIG_PATH`."""
+    if CONFIG_PATH.exists():
+        try:
+            with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            return {**DEFAULT_CONFIG, **{k: bool(v) for k, v in data.items()}}
+        except Exception:
+            return DEFAULT_CONFIG.copy()
+    CONFIG_PATH.write_text(json.dumps(DEFAULT_CONFIG, indent=2, ensure_ascii=False))
+    return DEFAULT_CONFIG.copy()
+
+
+def save_dashboard_config(config: dict) -> None:
+    """Write *config* to :data:`CONFIG_PATH`."""
+    with CONFIG_PATH.open("w", encoding="utf-8") as fh:
+        json.dump(config, fh, ensure_ascii=False, indent=2)
+
+
+def build_summary_text(total: int, amount: float, avg: float, config: dict) -> str:
+    """Return summary text based on *config*."""
+    lines: list[str] = []
+    if config.get("show_total_count", True):
+        lines.append(f"Nombre d'achats : {total}")
+    if config.get("show_total_amount", True):
+        lines.append(f"Total : {amount:.2f} \u20ac")
+    if config.get("show_avg_per_month", True):
+        lines.append(f"Moyenne par mois : {avg:.2f} \u20ac")
+    return "\n".join(lines)
+
+
 class DashboardWidget(QWidget):
     """Widget displaying purchase statistics with an optional graph."""
+
+    journal_requested = Signal()
+    grand_livre_requested = Signal()
+    scraping_summary_requested = Signal()
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         init_db(DB_PATH)
 
+        self.config = load_dashboard_config()
+
         layout = QVBoxLayout(self)
+
+        nav_layout = QHBoxLayout()
+        journal_btn = QPushButton("Journal")
+        journal_btn.clicked.connect(self.journal_requested.emit)
+        nav_layout.addWidget(journal_btn)
+
+        grand_btn = QPushButton("Grand Livre")
+        grand_btn.clicked.connect(self.grand_livre_requested.emit)
+        nav_layout.addWidget(grand_btn)
+
+        scrap_btn = QPushButton("Dernier scraping")
+        scrap_btn.clicked.connect(self.scraping_summary_requested.emit)
+        nav_layout.addWidget(scrap_btn)
+        layout.addLayout(nav_layout)
+
         self.summary_label = QLabel()
         layout.addWidget(self.summary_label)
 
@@ -48,6 +116,35 @@ class DashboardWidget(QWidget):
                 QLabel("matplotlib requis pour l'affichage du graphique")
             )
 
+        config_layout = QHBoxLayout()
+        self.count_cb = QCheckBox("Nombre")
+        self.amount_cb = QCheckBox("Total")
+        self.avg_cb = QCheckBox("Moyenne/mois")
+        self.chart_cb = QCheckBox("Graphique")
+        for key, cb in [
+            ("show_total_count", self.count_cb),
+            ("show_total_amount", self.amount_cb),
+            ("show_avg_per_month", self.avg_cb),
+            ("show_chart", self.chart_cb),
+        ]:
+            cb.setChecked(self.config.get(key, True))
+            cb.stateChanged.connect(self._config_changed)
+            config_layout.addWidget(cb)
+        layout.addLayout(config_layout)
+
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def _config_changed(self) -> None:
+        """Persist config and refresh widgets when checkboxes change."""
+        self.config = {
+            "show_total_count": self.count_cb.isChecked(),
+            "show_total_amount": self.amount_cb.isChecked(),
+            "show_avg_per_month": self.avg_cb.isChecked(),
+            "show_chart": self.chart_cb.isChecked(),
+        }
+        save_dashboard_config(self.config)
         self.refresh()
 
     # ------------------------------------------------------------------
@@ -70,15 +167,19 @@ class DashboardWidget(QWidget):
         return total_count, total_amount, avg_per_month, by_month
 
     def _update_summary(self, total: int, amount: float, avg: float) -> None:
-        self.summary_label.setText(
-            f"Nombre d'achats : {total}\n"
-            f"Total : {amount:.2f} \u20ac\n"
-            f"Moyenne par mois : {avg:.2f} \u20ac"
-        )
+        text = build_summary_text(total, amount, avg, self.config)
+        self.summary_label.setText(text)
+        self.summary_label.setVisible(bool(text))
 
     def _update_chart(self, by_month: dict[str, float]) -> None:
         if not MPL_AVAILABLE or not self.figure:
             return
+        if not self.config.get("show_chart", True):
+            if self.canvas:
+                self.canvas.hide()
+            return
+        if self.canvas:
+            self.canvas.show()
         self.figure.clear()
         ax = self.figure.add_subplot(111)
         months = sorted(by_month)

--- a/main.py
+++ b/main.py
@@ -167,6 +167,7 @@ class MainWindow(QMainWindow):
         scroll_content.setStyleSheet("background-color: #ffffff;")
 
         self.button_group: list[SidebarButton] = []
+        self.compta_buttons: dict[str, SidebarButton] = {}
 
         # Comptabilité section
         compta_section = CollapsibleSection(
@@ -183,6 +184,7 @@ class MainWindow(QMainWindow):
         }
         for name in compta_icons:
             btn = SidebarButton(name, icon_path=str(compta_icons[name]))
+            self.compta_buttons[name] = btn
             if name == "Tableau de bord":
                 self.dashboard_btn = btn
                 btn.clicked.connect(lambda _, b=btn: self.show_dashboard_page(b))
@@ -270,6 +272,15 @@ class MainWindow(QMainWindow):
 
         # Dashboard page showing purchase statistics
         self.dashboard_page = DashboardWidget()
+        self.dashboard_page.journal_requested.connect(
+            lambda: self.open_from_dashboard("Journal")
+        )
+        self.dashboard_page.grand_livre_requested.connect(
+            lambda: self.open_from_dashboard("Grand Livre")
+        )
+        self.dashboard_page.scraping_summary_requested.connect(
+            lambda: self.show_scraping_images(self.scrap_img_btn)
+        )
         self.stack.addWidget(self.dashboard_page)
 
         # Page for achats
@@ -337,6 +348,12 @@ class MainWindow(QMainWindow):
         self.clear_selection()
         button.setChecked(True)
         self.stack.setCurrentWidget(self.achat_page)
+
+    def open_from_dashboard(self, name: str) -> None:
+        """Open a comptabilité page from dashboard links."""
+        btn = self.compta_buttons.get(name)
+        if btn:
+            self.display_content(f"Comptabilité : {name}", btn)
 
     def show_settings(self) -> None:
         """Display the settings page."""

--- a/tests/test_dashboard_config.py
+++ b/tests/test_dashboard_config.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+import MOTEUR.dashboard_widget as dw
+
+
+def test_default_config_created(tmp_path: Path, monkeypatch) -> None:
+    cfg_path = tmp_path / "dash.json"
+    monkeypatch.setattr(dw, "CONFIG_PATH", cfg_path)
+    cfg = dw.load_dashboard_config()
+    assert cfg_path.exists()
+    assert cfg == dw.DEFAULT_CONFIG
+    with cfg_path.open() as fh:
+        data = json.load(fh)
+    assert data == dw.DEFAULT_CONFIG
+
+
+def test_build_summary_text_respects_flags() -> None:
+    cfg = {
+        "show_total_count": False,
+        "show_total_amount": True,
+        "show_avg_per_month": False,
+        "show_chart": True,
+    }
+    text = dw.build_summary_text(3, 99.5, 10.0, cfg)
+    assert "99.50" in text
+    assert "Nombre" not in text
+    assert "Moyenne" not in text


### PR DESCRIPTION
## Summary
- make dashboard indicators configurable via a JSON file
- expose quick links from the dashboard to Journal, Grand Livre and scraping
- wire dashboard signals in the main window
- test dashboard configuration helpers

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780eb78ea4833080e099ff3a1f5f16