### PR TITLE
Fix imports and trailing newlines

### DIFF
--- a/MOTEUR/accounting_db.py
+++ b/MOTEUR/accounting_db.py
@@ -143,7 +143,3 @@ def export_fec(db_path: Path | str, year: int, dest: Path) -> None:
                     f"{desc or ref};{debit:.2f};{credit:.2f}\n"
                 )
                 line_num += 1
-
-
-
-

--- a/MOTEUR/achat_db.py
+++ b/MOTEUR/achat_db.py
@@ -295,4 +295,3 @@ def get_vat_summary(db_path: Path | str, start: str, end: str) -> List[VatLine]:
     with connect(db_path) as conn:
         cur = conn.execute(SQL_VAT_SUMMARY, (start, end))
         return [VatLine(rate=r[0], base=r[1], vat=r[2]) for r in cur.fetchall()]
-

--- a/MOTEUR/dashboard_widget.py
+++ b/MOTEUR/dashboard_widget.py
@@ -199,4 +199,3 @@ class DashboardWidget(QWidget):
         total, amount, avg, by_month = self._compute_metrics(rows)
         self._update_summary(total, amount, avg)
         self._update_chart(by_month)
-

--- a/MOTEUR/models.py
+++ b/MOTEUR/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import Optional
 
 
 @dataclass

--- a/sample_data.py
+++ b/sample_data.py
@@ -33,4 +33,3 @@ def load_demo() -> None:
 
 if __name__ == "__main__":
     load_demo()
-

--- a/tests/test_achat_module.py
+++ b/tests/test_achat_module.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from MOTEUR.achat_db import init_db, add_purchase, pay_purchase, fetch_purchases, get_vat_summary
-from MOTEUR.models import Purchase, PurchaseFilter
+from MOTEUR.achat_db import init_db, add_purchase, pay_purchase, get_vat_summary
+from MOTEUR.models import Purchase
 from MOTEUR.db import connect
 from MOTEUR.accounting_db import entry_balanced
 
@@ -47,5 +47,3 @@ def test_payment_creates_entry(tmp_path: Path) -> None:
             ("INV1",),
         )
         assert cur.fetchone()[0] == 1
-
-

--- a/tests/test_fec_export.py
+++ b/tests/test_fec_export.py
@@ -20,5 +20,3 @@ def test_export_fec_generates_file(tmp_path: Path) -> None:
         lines = fh.readlines()
     # header + 3 lines
     assert len(lines) == 4
-
-


### PR DESCRIPTION
## Summary
- clean typing import in models
- remove unused imports in achat tests
- trim blank lines in several modules and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878a83399fc833087320f0d8cb79584