### PR TITLE
Add account management GUI

### DIFF
--- a/MOTEUR/compta/accounting/db.py
+++ b/MOTEUR/compta/accounting/db.py
@@ -229,3 +229,56 @@ def apply_letter(db_path: Path | str, code: str, entry_ids: list[int]) -> None:
             [code, *entry_ids],
         )
         conn.commit()
+
+
+def add_account(
+    db_path: Path | str,
+    code: str,
+    name: str,
+    parent_code: str | None = None,
+) -> None:
+    """Insert or replace an account."""
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO accounts(code, name, parent_code) VALUES (?,?,?)",
+            (code, name, parent_code),
+        )
+        conn.commit()
+
+
+def update_account(
+    db_path: Path | str,
+    code: str,
+    name: str,
+    parent_code: str | None = None,
+) -> None:
+    """Update the *name* or *parent_code* of an account."""
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE accounts SET name=?, parent_code=? WHERE code=?",
+            (name, parent_code, code),
+        )
+        conn.commit()
+
+
+def delete_account(db_path: Path | str, code: str) -> None:
+    """Remove account with given *code*."""
+    with connect(db_path) as conn:
+        conn.execute("DELETE FROM accounts WHERE code=?", (code,))
+        conn.commit()
+
+
+def fetch_accounts(db_path: Path | str, prefix: str | None = None):
+    """Return all accounts, optionally filtered by *prefix*."""
+    with connect(db_path) as conn:
+        if prefix:
+            cur = conn.execute(
+                "SELECT code, name FROM accounts WHERE code LIKE ? ORDER BY code",
+                (f"{prefix}%",),
+            )
+        else:
+            cur = conn.execute(
+                "SELECT code, name FROM accounts ORDER BY code",
+            )
+        rows = cur.fetchall()
+        return [(r[0], r[1]) for r in rows]

--- a/MOTEUR/compta/accounting/widget.py
+++ b/MOTEUR/compta/accounting/widget.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import Qt, Slot, Signal
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QMessageBox,
+)
+
+from .db import (
+    init_db,
+    add_account,
+    update_account,
+    delete_account,
+    fetch_accounts,
+)
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+# Default path to the SQLite database
+db_path = BASE_DIR / "compta.db"
+
+
+class AccountWidget(QWidget):
+    """Widget for simple account management."""
+
+    accounts_updated = Signal()
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        init_db(db_path)
+
+        layout = QVBoxLayout(self)
+
+        form_layout = QHBoxLayout()
+        form_layout.addWidget(QLabel("Numéro:"))
+        self.code_edit = QLineEdit()
+        form_layout.addWidget(self.code_edit)
+        form_layout.addWidget(QLabel("Libellé:"))
+        self.name_edit = QLineEdit()
+        form_layout.addWidget(self.name_edit)
+        layout.addLayout(form_layout)
+
+        btn_layout = QHBoxLayout()
+        self.add_btn = QPushButton("Ajouter")
+        self.add_btn.clicked.connect(self.add_account)
+        btn_layout.addWidget(self.add_btn)
+        self.mod_btn = QPushButton("Modifier")
+        self.mod_btn.clicked.connect(self.edit_account)
+        btn_layout.addWidget(self.mod_btn)
+        self.del_btn = QPushButton("Supprimer")
+        self.del_btn.clicked.connect(self.remove_account)
+        btn_layout.addWidget(self.del_btn)
+        layout.addLayout(btn_layout)
+
+        self.table = QTableWidget(0, 2)
+        self.table.setHorizontalHeaderLabels(["Numéro", "Libellé"])
+        self.table.verticalHeader().setVisible(False)
+        self.table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.table.cellClicked.connect(self.fill_fields_from_row)
+        layout.addWidget(self.table)
+
+        self.load_accounts()
+
+    # ------------------------------------------------------------------
+    def get_selected_code(self) -> str | None:
+        row = self.table.currentRow()
+        if row < 0:
+            return None
+        item = self.table.item(row, 0)
+        if not item:
+            return None
+        return item.text()
+
+    # ------------------------------------------------------------------
+    def load_accounts(self) -> None:
+        self.table.setRowCount(0)
+        for code, name in fetch_accounts(db_path):
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            self.table.setItem(row, 0, QTableWidgetItem(code))
+            self.table.setItem(row, 1, QTableWidgetItem(name))
+        self.code_edit.clear()
+        self.name_edit.clear()
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def add_account(self) -> None:
+        code = self.code_edit.text().strip()
+        name = self.name_edit.text().strip()
+        if not code or not name:
+            QMessageBox.warning(self, "Compte", "Numéro ou libellé manquant")
+            return
+        add_account(db_path, code, name)
+        self.load_accounts()
+        self.account_changed()
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def edit_account(self) -> None:
+        code = self.get_selected_code()
+        if code is None:
+            QMessageBox.warning(self, "Compte", "Sélectionnez un compte")
+            return
+        name = self.name_edit.text().strip()
+        if not name:
+            QMessageBox.warning(self, "Compte", "Libellé manquant")
+            return
+        update_account(db_path, code, name)
+        self.load_accounts()
+        self.account_changed()
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def remove_account(self) -> None:
+        code = self.get_selected_code()
+        if code is None:
+            QMessageBox.warning(self, "Compte", "Sélectionnez un compte")
+            return
+        delete_account(db_path, code)
+        self.load_accounts()
+        self.account_changed()
+
+    # ------------------------------------------------------------------
+    @Slot(int, int)
+    def fill_fields_from_row(self, row: int, column: int) -> None:
+        item_code = self.table.item(row, 0)
+        item_name = self.table.item(row, 1)
+        if item_code and item_name:
+            self.code_edit.setText(item_code.text())
+            self.name_edit.setText(item_name.text())
+
+    # Signal used to notify other widgets that the accounts have changed
+    def account_changed(self) -> None:
+        self.accounts_updated.emit()

--- a/MOTEUR/compta/achats/widget.py
+++ b/MOTEUR/compta/achats/widget.py
@@ -146,6 +146,11 @@ class AchatWidget(QWidget):
             for code, name in cur.fetchall():
                 self.account_combo.addItem(f"{code} {name}", code)
 
+    @Slot()
+    def refresh_accounts(self) -> None:
+        """Reload expense accounts from the DB."""
+        self.load_expense_accounts()
+
     def get_next_inv(self) -> str:
         with connect(db_path) as conn:
             return next_sequence(conn, "AC", QDate.currentDate().year())

--- a/MOTEUR/compta/compta.txt
+++ b/MOTEUR/compta/compta.txt
@@ -240,6 +240,57 @@ def apply_letter(db_path: Path | str, code: str, entry_ids: list[int]) -> None:
         )
         conn.commit()
 
+def add_account(
+    db_path: Path | str,
+    code: str,
+    name: str,
+    parent_code: str | None = None,
+) -> None:
+    """Insert or replace an account."""
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO accounts(code, name, parent_code) VALUES (?,?,?)",
+            (code, name, parent_code),
+        )
+        conn.commit()
+
+
+def update_account(
+    db_path: Path | str,
+    code: str,
+    name: str,
+    parent_code: str | None = None,
+) -> None:
+    """Update the *name* or *parent_code* of an account."""
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE accounts SET name=?, parent_code=? WHERE code=?",
+            (name, parent_code, code),
+        )
+        conn.commit()
+
+
+def delete_account(db_path: Path | str, code: str) -> None:
+    """Remove account with given *code*."""
+    with connect(db_path) as conn:
+        conn.execute("DELETE FROM accounts WHERE code=?", (code,))
+        conn.commit()
+
+
+def fetch_accounts(db_path: Path | str, prefix: str | None = None):
+    """Return all accounts, optionally filtered by *prefix*."""
+    with connect(db_path) as conn:
+        if prefix:
+            cur = conn.execute(
+                "SELECT code, name FROM accounts WHERE code LIKE ? ORDER BY code",
+                (f"{prefix}%",),
+            )
+        else:
+            cur = conn.execute(
+                "SELECT code, name FROM accounts ORDER BY code",
+            )
+        return cur.fetchall()
+
 ===== MOTEUR/compta/achats/__init__.py =====
 
 
@@ -1536,3 +1587,79 @@ class VenteWidget(QWidget):
             )
             self.label_edit.setText(item_label.text())
             self.amount_spin.setValue(float(item_amount.text()))
+
+
+===== MOTEUR/compta/accounting/widget.py =====
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import Qt, Slot, Signal
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QMessageBox,
+)
+
+from .db import (
+    init_db,
+    add_account,
+    update_account,
+    delete_account,
+    fetch_accounts,
+)
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+# Default path to the SQLite database
+db_path = BASE_DIR / "compta.db"
+
+
+class AccountWidget(QWidget):
+    """Widget for simple account management."""
+
+    accounts_updated = Signal()
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        init_db(db_path)
+
+        layout = QVBoxLayout(self)
+
+        form_layout = QHBoxLayout()
+        form_layout.addWidget(QLabel("Numéro:"))
+        self.code_edit = QLineEdit()
+        form_layout.addWidget(self.code_edit)
+        form_layout.addWidget(QLabel("Libellé:"))
+        self.name_edit = QLineEdit()
+        form_layout.addWidget(self.name_edit)
+        layout.addLayout(form_layout)
+
+        btn_layout = QHBoxLayout()
+        self.add_btn = QPushButton("Ajouter")
+        self.add_btn.clicked.connect(self.add_account)
+        btn_layout.addWidget(self.add_btn)
+        self.mod_btn = QPushButton("Modifier")
+        self.mod_btn.clicked.connect(self.edit_account)
+        btn_layout.addWidget(self.mod_btn)
+        self.del_btn = QPushButton("Supprimer")
+        self.del_btn.clicked.connect(self.remove_account)
+        btn_layout.addWidget(self.del_btn)
+        layout.addLayout(btn_layout)
+
+        self.table = QTableWidget(0, 2)
+        self.table.setHorizontalHeaderLabels(["Numéro", "Libellé"])
+        self.table.verticalHeader().setVisible(False)
+        self.table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.table.cellClicked.connect(self.fill_fields_from_row)
+        layout.addWidget(self.table)
+
+        self.load_accounts()

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Modules prévus (roadmap)
  Interface de base avec sidebar
 
  Module de saisie comptable (journal, écritures, plan comptable)
- 
-  Ajout des onglets "Achat" et "Ventes" dans la section Comptabilité
+
+  Ajout des onglets "Achat", "Ventes" et "Comptes" dans la section Comptabilité
 
  Génération automatique du bilan et du compte de résultat
 

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError:
 from MOTEUR.scraping.widgets.scraping_widget import ScrapingImagesWidget
 from MOTEUR.compta.achats.widget import AchatWidget
 from MOTEUR.compta.ventes.widget import VenteWidget
+from MOTEUR.compta.accounting.widget import AccountWidget
 from MOTEUR.scraping.widgets.profile_widget import ProfileWidget
 from MOTEUR.compta.dashboard.widget import DashboardWidget
 import subprocess
@@ -185,6 +186,7 @@ class MainWindow(QMainWindow):
             "Grand Livre": BASE_DIR / "icons" / "grand_livre.svg",
             "Bilan": BASE_DIR / "icons" / "bilan.svg",
             "Résultat": BASE_DIR / "icons" / "resultat.svg",
+            "Comptes": BASE_DIR / "icons" / "journal.svg",
             "Achat": BASE_DIR / "icons" / "achat.svg",
             "Ventes": BASE_DIR / "icons" / "ventes.svg",
         }
@@ -200,6 +202,11 @@ class MainWindow(QMainWindow):
                 self.achat_btn = btn
                 btn.clicked.connect(
                     lambda _, b=btn: self.show_achat_page(b)
+                )
+            elif name == "Comptes":
+                self.accounts_btn = btn
+                btn.clicked.connect(
+                    lambda _, b=btn: self.show_accounts_page(b)
                 )
             elif name == "Ventes":
                 self.ventes_btn = btn
@@ -302,6 +309,13 @@ class MainWindow(QMainWindow):
         self.achat_page = AchatWidget()
         self.stack.addWidget(self.achat_page)
 
+        # Page for account management
+        self.accounts_page = AccountWidget()
+        self.accounts_page.accounts_updated.connect(
+            self.achat_page.refresh_accounts
+        )
+        self.stack.addWidget(self.accounts_page)
+
         # Page for ventes
         self.ventes_page = VenteWidget()
         self.stack.addWidget(self.ventes_page)
@@ -365,6 +379,12 @@ class MainWindow(QMainWindow):
         button.setChecked(True)
         self.dashboard_page.refresh()
         self.stack.setCurrentWidget(self.dashboard_page)
+
+    def show_accounts_page(self, button: SidebarButton) -> None:
+        """Display the account management page."""
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.accounts_page)
 
     def show_achat_page(self, button: SidebarButton) -> None:
         """Display the achat page."""

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,27 @@
+from MOTEUR.compta.accounting.db import (
+    init_db,
+    add_account,
+    update_account,
+    delete_account,
+    fetch_accounts,
+)
+
+
+def test_accounts_crud(tmp_path):
+    db = tmp_path / "acc.db"
+    init_db(db)
+
+    add_account(db, "601", "Achats")
+    add_account(db, "701", "Ventes")
+
+    accts = fetch_accounts(db)
+    assert ("601", "Achats") in accts
+    assert ("701", "Ventes") in accts
+
+    update_account(db, "601", "Fournitures")
+    accts = fetch_accounts(db)
+    assert ("601", "Fournitures") in accts
+
+    delete_account(db, "701")
+    accts = fetch_accounts(db)
+    assert all(code != "701" for code, _ in accts)


### PR DESCRIPTION
## Summary
- allow CRUD operations on accounts in `accounting.db`
- add new `AccountWidget` and wire it into the main UI
- refresh purchase accounts when modified
- document new "Comptes" tab in README
- include new unit tests and update text listings

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878d7ae7cac83309eb523071a39f9ed