### PR TITLE
Add journal management and purchase dialog update

### DIFF
--- a/MOTEUR/compta/accounting/db.py
+++ b/MOTEUR/compta/accounting/db.py
@@ -296,3 +296,39 @@ def fetch_accounts(db_path: Path | str, prefix: str | None = None):
             )
         rows = cur.fetchall()
         return [(r[0], r[1]) for r in rows]
+
+
+def add_journal(db_path: Path | str, code: str, name: str) -> None:
+    """Insert or replace a journal."""
+    with connect(db_path) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO journals(code, name) VALUES (?, ?)",
+            (code, name),
+        )
+        conn.commit()
+
+
+def update_journal(db_path: Path | str, code: str, name: str) -> None:
+    """Update the *name* of a journal."""
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE journals SET name=? WHERE code=?",
+            (name, code),
+        )
+        conn.commit()
+
+
+def delete_journal(db_path: Path | str, code: str) -> None:
+    """Delete journal with *code*."""
+    with connect(db_path) as conn:
+        conn.execute("DELETE FROM journals WHERE code=?", (code,))
+        conn.commit()
+
+
+def fetch_journals(db_path: Path | str):
+    """Return list of journals as (code, name)."""
+    with connect(db_path) as conn:
+        cur = conn.execute(
+            "SELECT code, name FROM journals ORDER BY code"
+        )
+        return [(r[0], r[1]) for r in cur.fetchall()]

--- a/MOTEUR/compta/achats/piece_dialog.py
+++ b/MOTEUR/compta/achats/piece_dialog.py
@@ -16,6 +16,9 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QPushButton,
     QDoubleSpinBox,
+    QCheckBox,
+    QTableWidget,
+    QTableWidgetItem,
     QVBoxLayout,
 )
 
@@ -29,6 +32,7 @@ class PieceDialog(QDialog):
         self,
         suppliers: Iterable[Tuple[int, str]],
         accounts: Iterable[Tuple[str, str]],
+        journals: Iterable[Tuple[str, str]],
         next_piece: str,
         parent=None,
     ) -> None:
@@ -39,9 +43,10 @@ class PieceDialog(QDialog):
         layout = QVBoxLayout(self)
         form = QFormLayout()
 
-        self.date_edit = QDateEdit(QDate.currentDate())
-        self.date_edit.setCalendarPopup(True)
-        form.addRow("Date", self.date_edit)
+        self.journal_combo = QComboBox()
+        for code, name in journals:
+            self.journal_combo.addItem(code, code)
+        form.addRow("Journal", self.journal_combo)
 
         self.supplier_combo = QComboBox()
         self.supplier_combo.setEditable(True)
@@ -49,8 +54,21 @@ class PieceDialog(QDialog):
             self.supplier_combo.addItem(name, sid)
         form.addRow("Fournisseur", self.supplier_combo)
 
+        self.account_names = {code: text for code, text in accounts}
+        self.account_combo = QComboBox()
+        for code, text in accounts:
+            self.account_combo.addItem(text, code)
+        form.addRow("Compte", self.account_combo)
+
+        self.date_edit = QDateEdit(QDate.currentDate())
+        self.date_edit.setCalendarPopup(True)
+        form.addRow("Date", self.date_edit)
+
         self.piece_edit = QLineEdit(next_piece)
         form.addRow("Pièce", self.piece_edit)
+
+        self.invoice_edit = QLineEdit()
+        form.addRow("Facture", self.invoice_edit)
 
         self.label_edit = QLineEdit()
         form.addRow("Libellé", self.label_edit)
@@ -60,16 +78,14 @@ class PieceDialog(QDialog):
         self.ttc_spin.setMaximum(1e9)
         form.addRow("Montant TTC", self.ttc_spin)
 
+        self.credit_note_cb = QCheckBox()
+        form.addRow("Avoir", self.credit_note_cb)
+
         self.vat_combo = QComboBox()
         for rate in [0, 2.1, 5.5, 10, 20]:
             self.vat_combo.addItem(str(rate))
         self.vat_combo.setCurrentText("20")
         form.addRow("Taux TVA", self.vat_combo)
-
-        self.account_combo = QComboBox()
-        for code, text in accounts:
-            self.account_combo.addItem(text, code)
-        form.addRow("Compte 6xx", self.account_combo)
 
         self.attach_edit = QLineEdit()
         attach_btn = QPushButton("…")
@@ -80,6 +96,30 @@ class PieceDialog(QDialog):
         form.addRow("Justificatif", attach_layout)
 
         layout.addLayout(form)
+
+        self.lines_table = QTableWidget(0, 7)
+        self.lines_table.setHorizontalHeaderLabels(
+            [
+                "Compte",
+                "Libellé compte",
+                "Code TVA",
+                "Libellé écriture",
+                "Débit",
+                "Crédit",
+                "Montant TVA",
+            ]
+        )
+        self.lines_table.verticalHeader().setVisible(False)
+        self.lines_table.setEditTriggers(QTableWidget.NoEditTriggers)
+        layout.addWidget(self.lines_table)
+
+        # update lines when inputs change
+        self.ttc_spin.valueChanged.connect(self._update_lines)
+        self.vat_combo.currentIndexChanged.connect(self._update_lines)
+        self.account_combo.currentIndexChanged.connect(self._update_lines)
+        self.label_edit.textChanged.connect(self._update_lines)
+
+        self._update_lines()
 
         buttons = QDialogButtonBox(
             QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent=self
@@ -95,6 +135,49 @@ class PieceDialog(QDialog):
         )
         if path:
             self.attach_edit.setText(path)
+
+    # --------------------------------------------------------------
+    def _update_lines(self) -> None:
+        """Refresh the preview table with generated lines."""
+        ht = round(self.ttc_spin.value() / (1 + float(self.vat_combo.currentText()) / 100), 2)
+        vat = round(self.ttc_spin.value() - ht, 2)
+        account = self.account_combo.currentData()
+        vat_account = "44562" if str(account).startswith("2") else "44566"
+        credit_account = "401"
+        self.lines_table.setRowCount(0)
+        desc = self.label_edit.text().strip() or ""
+        # purchase line
+        row = self.lines_table.rowCount()
+        self.lines_table.insertRow(row)
+        self.lines_table.setItem(row, 0, QTableWidgetItem(str(account)))
+        self.lines_table.setItem(row, 1, QTableWidgetItem(self.account_names.get(account, "")))
+        self.lines_table.setItem(row, 2, QTableWidgetItem(""))
+        self.lines_table.setItem(row, 3, QTableWidgetItem(desc))
+        self.lines_table.setItem(row, 4, QTableWidgetItem(f"{ht:.2f}"))
+        self.lines_table.setItem(row, 5, QTableWidgetItem(""))
+        self.lines_table.setItem(row, 6, QTableWidgetItem(""))
+
+        # vat line
+        row = self.lines_table.rowCount()
+        self.lines_table.insertRow(row)
+        self.lines_table.setItem(row, 0, QTableWidgetItem(vat_account))
+        self.lines_table.setItem(row, 1, QTableWidgetItem("TVA"))
+        self.lines_table.setItem(row, 2, QTableWidgetItem(self.vat_combo.currentText()))
+        self.lines_table.setItem(row, 3, QTableWidgetItem(desc))
+        self.lines_table.setItem(row, 4, QTableWidgetItem(f"{vat:.2f}"))
+        self.lines_table.setItem(row, 5, QTableWidgetItem(""))
+        self.lines_table.setItem(row, 6, QTableWidgetItem(f"{vat:.2f}"))
+
+        # credit line
+        row = self.lines_table.rowCount()
+        self.lines_table.insertRow(row)
+        self.lines_table.setItem(row, 0, QTableWidgetItem(credit_account))
+        self.lines_table.setItem(row, 1, QTableWidgetItem("Fournisseur"))
+        self.lines_table.setItem(row, 2, QTableWidgetItem(""))
+        self.lines_table.setItem(row, 3, QTableWidgetItem(desc))
+        self.lines_table.setItem(row, 4, QTableWidgetItem(""))
+        self.lines_table.setItem(row, 5, QTableWidgetItem(f"{self.ttc_spin.value():.2f}"))
+        self.lines_table.setItem(row, 6, QTableWidgetItem(""))
 
     # --------------------------------------------------------------
     def _validate(self) -> None:

--- a/MOTEUR/compta/achats/widget.py
+++ b/MOTEUR/compta/achats/widget.py
@@ -35,7 +35,7 @@ from .db import (
 )
 from .signals import signals
 from ..models import Purchase
-from ..accounting.db import next_sequence
+from ..accounting.db import next_sequence, fetch_journals
 from ..db import connect
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -182,7 +182,8 @@ class AchatWidget(QWidget):
             (self.account_combo.itemData(i), self.account_combo.itemText(i))
             for i in range(self.account_combo.count())
         ]
-        dlg = PieceDialog(suppliers, accounts, self.get_next_inv(), self)
+        journals = fetch_journals(db_path)
+        dlg = PieceDialog(suppliers, accounts, journals, self.get_next_inv(), self)
         if dlg.exec() == QDialog.Accepted:
             pur = dlg.to_purchase()
             if pur.supplier_id is None:

--- a/MOTEUR/compta/parameters/__init__.py
+++ b/MOTEUR/compta/parameters/__init__.py
@@ -1,0 +1,3 @@
+from .journals_widget import JournalsWidget
+
+__all__ = ["JournalsWidget"]

--- a/MOTEUR/compta/parameters/journals_widget.py
+++ b/MOTEUR/compta/parameters/journals_widget.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import Qt, Slot
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QMessageBox,
+)
+
+from ..accounting.db import (
+    init_db,
+    add_journal,
+    update_journal,
+    delete_journal,
+    fetch_journals,
+)
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+DB_PATH = BASE_DIR / "compta.db"
+
+
+class JournalsWidget(QWidget):
+    """Simple CRUD widget for accounting journals."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        init_db(DB_PATH)
+
+        layout = QVBoxLayout(self)
+
+        form_layout = QHBoxLayout()
+        form_layout.addWidget(QLabel("Code:"))
+        self.code_edit = QLineEdit()
+        form_layout.addWidget(self.code_edit)
+        form_layout.addWidget(QLabel("Libellé:"))
+        self.name_edit = QLineEdit()
+        form_layout.addWidget(self.name_edit)
+        layout.addLayout(form_layout)
+
+        btn_layout = QHBoxLayout()
+        self.add_btn = QPushButton("Ajouter")
+        self.add_btn.clicked.connect(self.add_journal)
+        btn_layout.addWidget(self.add_btn)
+        self.mod_btn = QPushButton("Modifier")
+        self.mod_btn.clicked.connect(self.edit_journal)
+        btn_layout.addWidget(self.mod_btn)
+        self.del_btn = QPushButton("Supprimer")
+        self.del_btn.clicked.connect(self.remove_journal)
+        btn_layout.addWidget(self.del_btn)
+        layout.addLayout(btn_layout)
+
+        self.table = QTableWidget(0, 2)
+        self.table.setHorizontalHeaderLabels(["Code", "Libellé"])
+        self.table.verticalHeader().setVisible(False)
+        self.table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.table.cellClicked.connect(self.fill_fields_from_row)
+        layout.addWidget(self.table)
+
+        self.load_journals()
+
+    # ------------------------------------------------------------------
+    def get_selected_code(self) -> str | None:
+        row = self.table.currentRow()
+        if row < 0:
+            return None
+        item = self.table.item(row, 0)
+        if not item:
+            return None
+        return item.text()
+
+    # ------------------------------------------------------------------
+    def load_journals(self) -> None:
+        self.table.setRowCount(0)
+        for code, name in fetch_journals(DB_PATH):
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            self.table.setItem(row, 0, QTableWidgetItem(code))
+            self.table.setItem(row, 1, QTableWidgetItem(name))
+        self.code_edit.clear()
+        self.name_edit.clear()
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def add_journal(self) -> None:
+        code = self.code_edit.text().strip()
+        name = self.name_edit.text().strip()
+        if not code or not name:
+            QMessageBox.warning(self, "Journal", "Code ou libellé manquant")
+            return
+        add_journal(DB_PATH, code, name)
+        self.load_journals()
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def edit_journal(self) -> None:
+        code = self.get_selected_code()
+        if code is None:
+            QMessageBox.warning(self, "Journal", "Sélectionnez un journal")
+            return
+        name = self.name_edit.text().strip()
+        if not name:
+            QMessageBox.warning(self, "Journal", "Libellé manquant")
+            return
+        update_journal(DB_PATH, code, name)
+        self.load_journals()
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def remove_journal(self) -> None:
+        code = self.get_selected_code()
+        if code is None:
+            QMessageBox.warning(self, "Journal", "Sélectionnez un journal")
+            return
+        delete_journal(DB_PATH, code)
+        self.load_journals()
+
+    # ------------------------------------------------------------------
+    @Slot(int, int)
+    def fill_fields_from_row(self, row: int, column: int) -> None:
+        item_code = self.table.item(row, 0)
+        item_name = self.table.item(row, 1)
+        if item_code and item_name:
+            self.code_edit.setText(item_code.text())
+            self.name_edit.setText(item_name.text())
+

--- a/main.py
+++ b/main.py
@@ -188,6 +188,7 @@ class MainWindow(QMainWindow):
             "Résultat": BASE_DIR / "icons" / "resultat.svg",
             "Comptes": BASE_DIR / "icons" / "journal.svg",
             "Révision": BASE_DIR / "icons" / "bilan.svg",
+            "Paramètres": BASE_DIR / "icons" / "settings.svg",
             "Achat": BASE_DIR / "icons" / "achat.svg",
             "Fournisseurs": BASE_DIR / "icons" / "achat.svg",
             "Ventes": BASE_DIR / "icons" / "ventes.svg",
@@ -219,6 +220,11 @@ class MainWindow(QMainWindow):
                 self.revision_btn = btn
                 btn.clicked.connect(
                     lambda _, b=btn: self.show_revision_page(b)
+                )
+            elif name == "Paramètres":
+                self.param_journals_btn = btn
+                btn.clicked.connect(
+                    lambda _, b=btn: self.show_journals_page(b)
                 )
             elif name == "Ventes":
                 self.ventes_btn = btn
@@ -337,6 +343,11 @@ class MainWindow(QMainWindow):
         )
         self.stack.addWidget(self.accounts_page)
 
+        from MOTEUR.compta.parameters import JournalsWidget
+
+        self.journals_page = JournalsWidget()
+        self.stack.addWidget(self.journals_page)
+
         from MOTEUR.compta.revision import RevisionTab
 
         self.revision_page = RevisionTab()
@@ -417,6 +428,12 @@ class MainWindow(QMainWindow):
         self.clear_selection()
         button.setChecked(True)
         self.stack.setCurrentWidget(self.revision_page)
+
+    def show_journals_page(self, button: SidebarButton) -> None:
+        """Display the journals management page."""
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.journals_page)
 
     def show_achat_page(self, button: SidebarButton) -> None:
         """Display the achat page."""

--- a/tests/test_purchase_dialog.py
+++ b/tests/test_purchase_dialog.py
@@ -9,7 +9,8 @@ def test_purchase_dialog_to_purchase():
     app = QApplication.instance() or QApplication([])
     suppliers = [(1, "Supplier")]
     accounts = [("601", "601 Achat")]
-    dlg = PieceDialog(suppliers, accounts, "PIECE1")
+    journals = [("AC", "Achat")]
+    dlg = PieceDialog(suppliers, accounts, journals, "PIECE1")
 
     dlg.date_edit.setDate(QDate(2025, 1, 1))
     dlg.supplier_combo.setCurrentIndex(0)


### PR DESCRIPTION
## Summary
- create `JournalsWidget` for simple journal CRUD
- expose journal CRUD functions in accounting db module
- extend `PieceDialog` with journal combo and preview table
- load journals in purchase widget and update related tests
- add sidebar entry and page for Journals in main window

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793db3f63c83309566bc14955b3f0b