### PR TITLE
Fix account balance view for empty accounts

### DIFF
--- a/MOTEUR/compta/revision/revision_services.py
+++ b/MOTEUR/compta/revision/revision_services.py
@@ -10,7 +10,7 @@ SQL_CREATE_VIEW = """
 CREATE VIEW IF NOT EXISTS account_balance_v AS
 SELECT a.code                  AS account_code,
        a.name                  AS account_name,
-       ROUND(SUM(el.debit - el.credit),2) AS balance
+       ROUND(IFNULL(SUM(el.debit - el.credit), 0), 2) AS balance
 FROM   accounts a
 LEFT JOIN entry_lines el ON el.account = a.code
 GROUP BY a.code;

--- a/tests/test_revision.py
+++ b/tests/test_revision.py
@@ -30,3 +30,14 @@ def test_transactions_dialog_rows(tmp_path: Path) -> None:
     add_purchase(db, p2)
     rows = get_account_transactions(db, "606300")
     assert [r.balance for r in rows] == [100.0, 150.0]
+
+
+def test_account_without_entries_has_zero_balance(tmp_path: Path) -> None:
+    db = tmp_path / "rev_zero.db"
+    init_db(db)
+    with connect(db) as conn:
+        conn.execute("INSERT INTO accounts (code, name) VALUES ('1000','Test')")
+        conn.commit()
+
+    balances = {code: bal for code, _, bal in get_accounts_with_balance(db)}
+    assert balances["1000"] == 0.0


### PR DESCRIPTION
## Summary
- return zero balance for accounts without entries
- test zero balance handling

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68794d5f92f4833095be5d506a7f8861