### PR TITLE
Fix None balance handling

### DIFF
--- a/MOTEUR/compta/revision/revision_tab.py
+++ b/MOTEUR/compta/revision/revision_tab.py
@@ -39,14 +39,19 @@ class RevisionTab(QWidget):
     @Slot()
     def refresh(self) -> None:
         self.table.setRowCount(0)
-        for code,name,bal in get_accounts_with_balance(DB_PATH):
-            r = self.table.rowCount(); self.table.insertRow(r)
-            item = QTableWidgetItem(code); item.setData(Qt.UserRole, code)
-            self.table.setItem(r,0,item)
-            self.table.setItem(r,1,QTableWidgetItem(name))
+        for code, name, bal in get_accounts_with_balance(DB_PATH):
+            r = self.table.rowCount()
+            self.table.insertRow(r)
+            item = QTableWidgetItem(code)
+            item.setData(Qt.UserRole, code)
+            self.table.setItem(r, 0, item)
+            self.table.setItem(r, 1, QTableWidgetItem(name))
+            # `bal` might be ``None`` if the SQL view returns NULL.
+            # Guard against it before formatting.
+            bal = bal if bal is not None else 0.0
             bal_item = QTableWidgetItem(f"{bal:.2f}")
-            bal_item.setForeground(Qt.darkGreen if bal>0 else Qt.red)
-            self.table.setItem(r,2,bal_item)
+            bal_item.setForeground(Qt.darkGreen if bal > 0 else Qt.red)
+            self.table.setItem(r, 2, bal_item)
 
     # ------------------------------------------------
     @Slot(int,int)

--- a/MOTEUR/compta/suppliers/supplier_services.py
+++ b/MOTEUR/compta/suppliers/supplier_services.py
@@ -10,7 +10,7 @@ SQL_CREATE_VIEW = """
 CREATE VIEW IF NOT EXISTS supplier_balance_v AS
 SELECT s.id      AS supplier_id,
        s.name    AS supplier_name,
-       ROUND(SUM(CASE WHEN el.debit>0 THEN el.debit ELSE -el.credit END),2) AS balance
+       ROUND(COALESCE(SUM(CASE WHEN el.debit>0 THEN el.debit ELSE -el.credit END), 0), 2) AS balance
 FROM suppliers s
 LEFT JOIN entries   e   ON e.ref IN (
       SELECT piece FROM purchases WHERE supplier_id = s.id)


### PR DESCRIPTION
## Summary
- guard against NULL balances in `RevisionTab.refresh`
- ensure supplier balance view defaults NULL totals to zero

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a2a927eb483308a74cc8c5c04cb3c