### PR TITLE
Add scraping variants widget

### DIFF
--- a/MOTEUR/scraping/scraping.txt
+++ b/MOTEUR/scraping/scraping.txt
@@ -1028,3 +1028,97 @@ class ScrapingImagesWidget(QWidget):
         if self.scrape_folder and self.scrape_folder.exists():
             QDesktopServices.openUrl(QUrl.fromLocalFile(str(self.scrape_folder)))
         self.start_btn.setEnabled(True)
+===== MOTEUR/scraping/widgets/variant_widget.py =====
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from PySide6.QtCore import QThread, Signal, Slot
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..scraping_variantes import (
+    VARIANT_DEFAULT_SELECTOR,
+    extract_variants,
+)
+
+
+class VariantWorker(QThread):
+    """Thread running the variant extraction."""
+
+    finished = Signal(str, list)
+
+    def __init__(self, url: str, selector: str) -> None:
+        super().__init__()
+        self.url = url
+        self.selector = selector
+
+    def run(self) -> None:  # noqa: D401 - QThread API
+        try:
+            title, variants = extract_variants(self.url, self.selector)
+        except Exception as exc:  # pragma: no cover - network/driver issues
+            logging.getLogger(__name__).error("%s", exc)
+            self.finished.emit("", [])
+            return
+        self.finished.emit(title, variants)
+
+
+class ScrapingVariantsWidget(QWidget):
+    """Simple GUI to scrape product variants from a URL."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+
+        self.url_edit = QLineEdit()
+        self.url_edit.setPlaceholderText("Lien du produit")
+        layout.addWidget(self.url_edit)
+
+        self.selector_edit = QLineEdit(VARIANT_DEFAULT_SELECTOR)
+        self.selector_edit.setPlaceholderText("Sélecteur CSS des variantes")
+        layout.addWidget(self.selector_edit)
+
+        start_row = QHBoxLayout()
+        start_row.addStretch()
+        self.start_btn = QPushButton("Lancer")
+        self.start_btn.clicked.connect(self.start_scraping)
+        start_row.addWidget(self.start_btn)
+        start_row.addStretch()
+        layout.addLayout(start_row)
+
+        self.console = QTextEdit()
+        self.console.setReadOnly(True)
+        layout.addWidget(self.console)
+
+        self.worker: VariantWorker | None = None
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def start_scraping(self) -> None:
+        url = self.url_edit.text().strip()
+        if not url:
+            self.console.append("⚠️ URL manquante")
+            return
+        selector = self.selector_edit.text().strip() or VARIANT_DEFAULT_SELECTOR
+        self.console.clear()
+        self.start_btn.setEnabled(False)
+
+        self.worker = VariantWorker(url, selector)
+        self.worker.finished.connect(self.scraping_finished)
+        self.worker.start()
+
+    @Slot(str, list)
+    def scraping_finished(self, title: str, variants: list[str]) -> None:
+        if title:
+            self.console.append(f"Produit: {title}")
+            for v in variants:
+                self.console.append(f"- {v}")
+        self.start_btn.setEnabled(True)

--- a/MOTEUR/scraping/widgets/__init__.py
+++ b/MOTEUR/scraping/widgets/__init__.py
@@ -1,0 +1,4 @@
+from .scraping_widget import ScrapingImagesWidget
+from .profile_widget import ProfileWidget
+from .variant_widget import ScrapingVariantsWidget
+

--- a/MOTEUR/scraping/widgets/variant_widget.py
+++ b/MOTEUR/scraping/widgets/variant_widget.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from PySide6.QtCore import QThread, Signal, Slot
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..scraping_variantes import (
+    VARIANT_DEFAULT_SELECTOR,
+    extract_variants,
+)
+
+
+class VariantWorker(QThread):
+    """Thread running the variant extraction."""
+
+    finished = Signal(str, list)
+
+    def __init__(self, url: str, selector: str) -> None:
+        super().__init__()
+        self.url = url
+        self.selector = selector
+
+    def run(self) -> None:  # noqa: D401 - QThread API
+        try:
+            title, variants = extract_variants(self.url, self.selector)
+        except Exception as exc:  # pragma: no cover - network/driver issues
+            logging.getLogger(__name__).error("%s", exc)
+            self.finished.emit("", [])
+            return
+        self.finished.emit(title, variants)
+
+
+class ScrapingVariantsWidget(QWidget):
+    """Simple GUI to scrape product variants from a URL."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+
+        self.url_edit = QLineEdit()
+        self.url_edit.setPlaceholderText("Lien du produit")
+        layout.addWidget(self.url_edit)
+
+        self.selector_edit = QLineEdit(VARIANT_DEFAULT_SELECTOR)
+        self.selector_edit.setPlaceholderText("Sélecteur CSS des variantes")
+        layout.addWidget(self.selector_edit)
+
+        start_row = QHBoxLayout()
+        start_row.addStretch()
+        self.start_btn = QPushButton("Lancer")
+        self.start_btn.clicked.connect(self.start_scraping)
+        start_row.addWidget(self.start_btn)
+        start_row.addStretch()
+        layout.addLayout(start_row)
+
+        self.console = QTextEdit()
+        self.console.setReadOnly(True)
+        layout.addWidget(self.console)
+
+        self.worker: VariantWorker | None = None
+
+    # ------------------------------------------------------------------
+    @Slot()
+    def start_scraping(self) -> None:
+        url = self.url_edit.text().strip()
+        if not url:
+            self.console.append("⚠️ URL manquante")
+            return
+        selector = self.selector_edit.text().strip() or VARIANT_DEFAULT_SELECTOR
+        self.console.clear()
+        self.start_btn.setEnabled(False)
+
+        self.worker = VariantWorker(url, selector)
+        self.worker.finished.connect(self.scraping_finished)
+        self.worker.start()
+
+    @Slot(str, list)
+    def scraping_finished(self, title: str, variants: list[str]) -> None:
+        if title:
+            self.console.append(f"Produit: {title}")
+            for v in variants:
+                self.console.append(f"- {v}")
+        self.start_btn.setEnabled(True)

--- a/icons/variants.svg
+++ b/icons/variants.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <circle cx="4" cy="4" r="3" fill="#555"/>
+  <circle cx="12" cy="4" r="3" fill="#555"/>
+  <circle cx="8" cy="12" r="3" fill="#555"/>
+</svg>

--- a/main.py
+++ b/main.py
@@ -264,6 +264,16 @@ class MainWindow(QMainWindow):
         scrap_section.add_widget(self.scrap_img_btn)
         self.button_group.append(self.scrap_img_btn)
 
+        self.scrap_var_btn = SidebarButton(
+            "Scraping Variantes",
+            icon_path=str(BASE_DIR / "icons" / "variants.svg"),
+        )
+        self.scrap_var_btn.clicked.connect(
+            lambda _, b=self.scrap_var_btn: self.show_scraping_variants(b)
+        )
+        scrap_section.add_widget(self.scrap_var_btn)
+        self.button_group.append(self.scrap_var_btn)
+
         btn = SidebarButton(
             "Scraping Descriptions",
             icon_path=str(BASE_DIR / "icons" / "text.svg"),
@@ -305,6 +315,10 @@ class MainWindow(QMainWindow):
         # Page for scraping images
         self.scraping_images_page = ScrapingImagesWidget()
         self.stack.addWidget(self.scraping_images_page)
+
+        from MOTEUR.scraping.widgets.variant_widget import ScrapingVariantsWidget
+        self.scraping_variants_page = ScrapingVariantsWidget()
+        self.stack.addWidget(self.scraping_variants_page)
 
         self.profile_page.profile_chosen.connect(
             self.scraping_images_page.set_selected_profile
@@ -403,6 +417,12 @@ class MainWindow(QMainWindow):
         self.clear_selection()
         button.setChecked(True)
         self.stack.setCurrentWidget(self.scraping_images_page)
+
+    def show_scraping_variants(self, button: SidebarButton) -> None:
+        """Display the scraping variants page."""
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.scraping_variants_page)
 
     def show_profiles(self, button: SidebarButton) -> None:
         """Display the profile management page."""


### PR DESCRIPTION
## Summary
- add new ScrapingVariantsWidget with start button and console
- expose new widget in module exports
- add sidebar button for variants scraping in main interface
- provide SVG icon for variants
- update scraping.txt listing with new module

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a36a1f414833094a6b1fda88080d2