### PR TITLE
Switch Woo URL widget to table

### DIFF
--- a/tests/test_woo_url_widget.py
+++ b/tests/test_woo_url_widget.py
@@ -1,5 +1,5 @@
 import pytest
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QTableWidgetItem
 
 from MOTEUR.scraping.widgets.woo_url_widget import WooImageURLWidget
 
@@ -16,7 +16,11 @@ def setup_widget():
 
 def test_verify_links_identifies_invalid(monkeypatch):
     widget = setup_widget()
-    widget.output.setPlainText("http://good.com\nhttp://bad.com")
+    widget.table.setRowCount(0)
+    widget.table.insertRow(0)
+    widget.table.setItem(0, 0, QTableWidgetItem("http://good.com"))
+    widget.table.insertRow(1)
+    widget.table.setItem(1, 0, QTableWidgetItem("http://bad.com"))
 
     def fake_head(url, allow_redirects=True, timeout=5):
         return DummyResp(200 if "good" in url else 404)
@@ -47,12 +51,16 @@ def test_verify_links_identifies_invalid(monkeypatch):
 
     assert "warn" in infos
     assert "invalide" in infos["warn"]
-    assert "❌ http://bad.com" in widget.output.toPlainText()
+    assert widget.table.item(1, 1).text() == "❌"
 
 
 def test_verify_links_all_valid(monkeypatch):
     widget = setup_widget()
-    widget.output.setPlainText("http://good.com\nhttp://also-good.com")
+    widget.table.setRowCount(0)
+    widget.table.insertRow(0)
+    widget.table.setItem(0, 0, QTableWidgetItem("http://good.com"))
+    widget.table.insertRow(1)
+    widget.table.setItem(1, 0, QTableWidgetItem("http://also-good.com"))
 
     def fake_head(url, allow_redirects=True, timeout=5):
         return DummyResp(200)
@@ -83,4 +91,5 @@ def test_verify_links_all_valid(monkeypatch):
 
     assert "warn" not in infos
     assert "Tous les liens" in infos.get("info", "")
-    assert "❌" not in widget.output.toPlainText()
+    assert widget.table.item(0, 1).text() == "✅"
+    assert widget.table.item(1, 1).text() == "✅"


### PR DESCRIPTION
## Summary
- swap Woo URL widget text box for a two-column table
- adjust copy/export/clear/verify logic for new table
- update tests for new widget design

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa33180d48330a441962a06ce62d4