### PR TITLE
Update variant widget to display image URLs

### DIFF
--- a/MOTEUR/scraping/scraping.txt
+++ b/MOTEUR/scraping/scraping.txt
@@ -1046,14 +1046,14 @@ from PySide6.QtWidgets import (
 
 from ..scraping_variantes import (
     VARIANT_DEFAULT_SELECTOR,
-    extract_variants,
+    extract_variants_with_images,
 )
 
 
 class VariantWorker(QThread):
     """Thread running the variant extraction."""
 
-    finished = Signal(str, list)
+    finished = Signal(str, dict)
 
     def __init__(self, url: str, selector: str) -> None:
         super().__init__()
@@ -1062,10 +1062,10 @@ class VariantWorker(QThread):
 
     def run(self) -> None:  # noqa: D401 - QThread API
         try:
-            title, variants = extract_variants(self.url, self.selector)
+            title, variants = extract_variants_with_images(self.url)
         except Exception as exc:  # pragma: no cover - network/driver issues
             logging.getLogger(__name__).error("%s", exc)
-            self.finished.emit("", [])
+            self.finished.emit("", {})
             return
         self.finished.emit(title, variants)
 
@@ -1115,10 +1115,10 @@ class ScrapingVariantsWidget(QWidget):
         self.worker.finished.connect(self.scraping_finished)
         self.worker.start()
 
-    @Slot(str, list)
-    def scraping_finished(self, title: str, variants: list[str]) -> None:
+    @Slot(str, dict)
+    def scraping_finished(self, title: str, variants: dict[str, str]) -> None:
         if title:
             self.console.append(f"Produit: {title}")
-            for v in variants:
-                self.console.append(f"- {v}")
+            for name, link in variants.items():
+                self.console.append(f"- {name} : {link}")
         self.start_btn.setEnabled(True)

--- a/MOTEUR/scraping/widgets/variant_widget.py
+++ b/MOTEUR/scraping/widgets/variant_widget.py
@@ -15,14 +15,14 @@ from PySide6.QtWidgets import (
 
 from ..scraping_variantes import (
     VARIANT_DEFAULT_SELECTOR,
-    extract_variants,
+    extract_variants_with_images,
 )
 
 
 class VariantWorker(QThread):
     """Thread running the variant extraction."""
 
-    finished = Signal(str, list)
+    finished = Signal(str, dict)
 
     def __init__(self, url: str, selector: str) -> None:
         super().__init__()
@@ -31,10 +31,10 @@ class VariantWorker(QThread):
 
     def run(self) -> None:  # noqa: D401 - QThread API
         try:
-            title, variants = extract_variants(self.url, self.selector)
+            title, variants = extract_variants_with_images(self.url)
         except Exception as exc:  # pragma: no cover - network/driver issues
             logging.getLogger(__name__).error("%s", exc)
-            self.finished.emit("", [])
+            self.finished.emit("", {})
             return
         self.finished.emit(title, variants)
 
@@ -84,10 +84,10 @@ class ScrapingVariantsWidget(QWidget):
         self.worker.finished.connect(self.scraping_finished)
         self.worker.start()
 
-    @Slot(str, list)
-    def scraping_finished(self, title: str, variants: list[str]) -> None:
+    @Slot(str, dict)
+    def scraping_finished(self, title: str, variants: dict[str, str]) -> None:
         if title:
             self.console.append(f"Produit: {title}")
-            for v in variants:
-                self.console.append(f"- {v}")
+            for name, link in variants.items():
+                self.console.append(f"- {name} : {link}")
         self.start_btn.setEnabled(True)

--- a/tests/test_variant_widget.py
+++ b/tests/test_variant_widget.py
@@ -1,0 +1,18 @@
+from PySide6.QtWidgets import QApplication
+
+from MOTEUR.scraping.widgets.variant_widget import ScrapingVariantsWidget
+
+
+def setup_widget():
+    app = QApplication.instance() or QApplication([])
+    return ScrapingVariantsWidget()
+
+
+def test_scraping_finished_displays_variants():
+    widget = setup_widget()
+    data = {"Red": "http://img/red.jpg", "Blue": "http://img/blue.jpg"}
+    widget.scraping_finished("My Product", data)
+    text = widget.console.toPlainText()
+    assert "Produit: My Product" in text
+    for name, url in data.items():
+        assert f"- {name} : {url}" in text


### PR DESCRIPTION
## Summary
- support image URLs in variant scraping
- document widget update
- test variant widget display

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aac35bdc483309d6f8d7dac4dcebe