### PR TITLE
Ensure Woo links sorted consistently

### DIFF
--- a/MOTEUR/scraping/scraping.txt
+++ b/MOTEUR/scraping/scraping.txt
@@ -1232,7 +1232,7 @@ class VariantComparisonWidget(QWidget):
 
         base_url = self.domain_edit.text().strip().rstrip("/")
         links: list[str] = []
-        for file in self.folder_path.iterdir():
+        for file in sorted(self.folder_path.iterdir()):
             if file.suffix.lower() in self.ALLOWED_EXTENSIONS:
                 links.append(
                     f"{base_url}/wp-content/uploads/{date_path}/{file.name}"

--- a/MOTEUR/scraping/widgets/variant_comparison_widget.py
+++ b/MOTEUR/scraping/widgets/variant_comparison_widget.py
@@ -105,7 +105,7 @@ class VariantComparisonWidget(QWidget):
 
         base_url = self.domain_edit.text().strip().rstrip("/")
         links: list[str] = []
-        for file in self.folder_path.iterdir():
+        for file in sorted(self.folder_path.iterdir()):
             if file.suffix.lower() in self.ALLOWED_EXTENSIONS:
                 links.append(
                     f"{base_url}/wp-content/uploads/{date_path}/{file.name}"

--- a/tests/test_variant_comparison_widget.py
+++ b/tests/test_variant_comparison_widget.py
@@ -21,12 +21,8 @@ def test_table_populated_with_links(tmp_path: Path):
     widget.comparison_finished(data)
 
     assert widget.table.rowCount() == 2
-    links = {
-        widget.table.item(0, 1).text(),
-        widget.table.item(1, 1).text(),
-    }
-    assert any(link.endswith("a.jpg") for link in links)
-    assert any(link.endswith("b.png") for link in links)
+    assert widget.table.item(0, 1).text().endswith("a.jpg")
+    assert widget.table.item(1, 1).text().endswith("b.png")
     assert widget.table.item(0, 2).text() == "http://img/red.jpg"
     assert widget.table.item(1, 2).text() == "http://img/blue.jpg"
 
@@ -39,3 +35,12 @@ def test_missing_woo_link_fills_blank(tmp_path: Path):
 
     assert widget.table.rowCount() == 2
     assert widget.table.item(1, 1).text() == ""
+
+
+def test_generate_woo_links_sorted(tmp_path: Path):
+    (tmp_path / "b.jpg").touch()
+    (tmp_path / "a.png").touch()
+    widget = setup_widget(tmp_path)
+    links = widget.generate_woo_links()
+    assert links[0].endswith("a.png")
+    assert links[1].endswith("b.jpg")


### PR DESCRIPTION
## Summary
- sort WooCommerce file links alphabetically in `VariantComparisonWidget`
- document the new sorted iteration in `scraping.txt`
- update variant comparison tests for deterministic order

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab70f2e988330acd65789b058a7a2