### PR TITLE
Add combined scraping widget

### DIFF
--- a/MOTEUR/scraping/scraping.txt
+++ b/MOTEUR/scraping/scraping.txt
@@ -1262,3 +1262,66 @@ class VariantComparisonWidget(QWidget):
             self.table.setItem(row, 1, QTableWidgetItem(woo_link))
             self.table.setItem(row, 2, QTableWidgetItem(comp_link))
         self.start_btn.setEnabled(True)
+===== MOTEUR/scraping/widgets/combined_scrape_widget.py =====
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import Slot
+from PySide6.QtWidgets import (
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QProgressBar,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .scraping_widget import ScrapeWorker
+from ..scraping_variantes import extract_variants_with_images
+
+
+class CombinedScrapeWidget(QWidget):
+    """Download images, extract variants and generate Woo links."""
+
+    ALLOWED_EXTENSIONS = {".webp", ".jpg", ".jpeg", ".png"}
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        # widgets setup (url, domain, date, table)
+        ...
+
+    def valid_date(self, text: str) -> bool:
+        return bool(re.fullmatch(r"\d{4}/\d{2}", text))
+
+    def generate_woo_links(self) -> list[str]:
+        if not self.scrape_folder:
+            return []
+        date_path = self.date_edit.text().strip()
+        if not self.valid_date(date_path):
+            return []
+        base_url = self.domain_edit.text().strip().rstrip("/")
+        links = [
+            f"{base_url}/wp-content/uploads/{date_path}/{f.name}"
+            for f in sorted(self.scrape_folder.iterdir())
+            if f.suffix.lower() in self.ALLOWED_EXTENSIONS
+        ]
+        return links
+
+    def populate_table(self, variants: dict[str, str]) -> None:
+        woo_links = self.generate_woo_links()
+        items = list(variants.items())
+        total = max(len(woo_links), len(items))
+        self.table.setRowCount(0)
+        for i in range(total):
+            name, comp = items[i] if i < len(items) else ("", "")
+            woo = woo_links[i] if i < len(woo_links) else ""
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            self.table.setItem(row, 0, QTableWidgetItem(name))
+            self.table.setItem(row, 1, QTableWidgetItem(woo))
+            self.table.setItem(row, 2, QTableWidgetItem(comp))

--- a/MOTEUR/scraping/widgets/__init__.py
+++ b/MOTEUR/scraping/widgets/__init__.py
@@ -3,4 +3,5 @@ from .profile_widget import ProfileWidget
 from .variant_widget import ScrapingVariantsWidget
 from .woo_url_widget import WooImageURLWidget
 from .variant_comparison_widget import VariantComparisonWidget
+from .combined_scrape_widget import CombinedScrapeWidget
 from .scrap_widget import ScrapWidget

--- a/MOTEUR/scraping/widgets/combined_scrape_widget.py
+++ b/MOTEUR/scraping/widgets/combined_scrape_widget.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import Slot
+from PySide6.QtWidgets import (
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QProgressBar,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .scraping_widget import ScrapeWorker
+from ..scraping_variantes import extract_variants_with_images
+
+
+class CombinedScrapeWidget(QWidget):
+    """Download images, extract variants and generate Woo links."""
+
+    ALLOWED_EXTENSIONS = {".webp", ".jpg", ".jpeg", ".png"}
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+
+        self.url_edit = QLineEdit()
+        self.url_edit.setPlaceholderText("Lien produit concurrent")
+        layout.addWidget(self.url_edit)
+
+        self.domain_label = QLabel("Domaine WooCommerce :")
+        self.domain_edit = QLineEdit("https://www.planetebob.fr")
+        layout.addWidget(self.domain_label)
+        layout.addWidget(self.domain_edit)
+
+        self.date_label = QLabel("Date (YYYY/MM) :")
+        self.date_edit = QLineEdit("2025/07")
+        layout.addWidget(self.date_label)
+        layout.addWidget(self.date_edit)
+
+        self.start_btn = QPushButton("Lancer")
+        self.start_btn.clicked.connect(self.start_process)
+        layout.addWidget(self.start_btn)
+
+        self.progress = QProgressBar()
+        self.progress.setRange(0, 100)
+        self.progress.hide()
+        layout.addWidget(self.progress)
+
+        self.table = QTableWidget(0, 3)
+        self.table.setHorizontalHeaderLabels([
+            "Variante",
+            "Lien Woo",
+            "Lien Concurrent",
+        ])
+        self.table.verticalHeader().setVisible(False)
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table)
+
+        self.scrape_folder: Path | None = None
+        self.worker: ScrapeWorker | None = None
+
+    # ------------------------------------------------------------------
+    def valid_date(self, text: str) -> bool:
+        return bool(re.fullmatch(r"\d{4}/\d{2}", text))
+
+    def generate_woo_links(self) -> list[str]:
+        if not self.scrape_folder:
+            return []
+        date_path = self.date_edit.text().strip()
+        if not self.valid_date(date_path):
+            return []
+        base_url = self.domain_edit.text().strip().rstrip("/")
+        links: list[str] = []
+        for file in sorted(self.scrape_folder.iterdir()):
+            if file.suffix.lower() in self.ALLOWED_EXTENSIONS:
+                links.append(
+                    f"{base_url}/wp-content/uploads/{date_path}/{file.name}"
+                )
+        return links
+
+    def populate_table(self, variants: dict[str, str]) -> None:
+        woo_links = self.generate_woo_links()
+        items = list(variants.items())
+        total = max(len(woo_links), len(items))
+        self.table.setRowCount(0)
+        for idx in range(total):
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            name, comp = (items[idx] if idx < len(items) else ("", ""))
+            woo = woo_links[idx] if idx < len(woo_links) else ""
+            self.table.setItem(row, 0, QTableWidgetItem(name))
+            self.table.setItem(row, 1, QTableWidgetItem(woo))
+            self.table.setItem(row, 2, QTableWidgetItem(comp))
+
+    @Slot()
+    def start_process(self) -> None:
+        url = self.url_edit.text().strip()
+        if not url:
+            return
+        self.start_btn.setEnabled(False)
+        self.progress.setValue(0)
+        self.progress.show()
+        self.worker = ScrapeWorker(url, "", "images")
+        self.worker.progress.connect(self.update_progress)
+        self.worker.finished.connect(self.scrape_finished)
+        self.worker.start()
+
+    @Slot(int, int)
+    def update_progress(self, current: int, total: int) -> None:
+        if total:
+            pct = int(current / total * 100)
+            self.progress.setValue(pct)
+
+    @Slot(dict)
+    def scrape_finished(self, result: dict) -> None:
+        self.scrape_folder = Path(result.get("folder", ""))
+        try:
+            _, variants = extract_variants_with_images(self.url_edit.text().strip())
+        except Exception:  # pragma: no cover - network issues
+            variants = {}
+        self.populate_table(variants)
+        self.progress.hide()
+        self.start_btn.setEnabled(True)

--- a/MOTEUR/scraping/widgets/scrap_widget.py
+++ b/MOTEUR/scraping/widgets/scrap_widget.py
@@ -8,6 +8,7 @@ from .scraping_widget import ScrapingImagesWidget
 from .variant_widget import ScrapingVariantsWidget
 from .woo_url_widget import WooImageURLWidget
 from .variant_comparison_widget import VariantComparisonWidget
+from .combined_scrape_widget import CombinedScrapeWidget
 
 
 class ScrapWidget(QWidget):
@@ -23,10 +24,12 @@ class ScrapWidget(QWidget):
         self.variants_widget = ScrapingVariantsWidget()
         self.woo_widget = WooImageURLWidget()
         self.compare_widget = VariantComparisonWidget()
+        self.combined_widget = CombinedScrapeWidget()
 
         self.tabs.addTab(self.images_widget, "Images")
         self.tabs.addTab(self.variants_widget, "Variantes")
         self.tabs.addTab(self.woo_widget, "Liens Woo")
         self.tabs.addTab(self.compare_widget, "Comparaison")
+        self.tabs.addTab(self.combined_widget, "Tout-en-un")
 
         layout.addWidget(self.tabs)

--- a/tests/test_combined_scrape_widget.py
+++ b/tests/test_combined_scrape_widget.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from PySide6.QtWidgets import QApplication, QTableWidgetItem
+
+from MOTEUR.scraping.widgets.combined_scrape_widget import CombinedScrapeWidget
+
+
+def setup_widget(tmp_path: Path) -> CombinedScrapeWidget:
+    app = QApplication.instance() or QApplication([])
+    widget = CombinedScrapeWidget()
+    widget.scrape_folder = tmp_path
+    widget.domain_edit.setText("https://shop.com")
+    widget.date_edit.setText("2024/05")
+    return widget
+
+
+def test_populate_table_with_extra_images(tmp_path: Path):
+    (tmp_path / "a.jpg").touch()
+    (tmp_path / "b.png").touch()
+    (tmp_path / "c.png").touch()
+    widget = setup_widget(tmp_path)
+    data = {"Red": "http://img/red.jpg", "Blue": "http://img/blue.jpg"}
+    widget.populate_table(data)
+
+    assert widget.table.rowCount() == 3
+    assert widget.table.item(0, 0).text() == "Red"
+    assert widget.table.item(1, 0).text() == "Blue"
+    assert widget.table.item(2, 0).text() == ""
+    assert widget.table.item(0, 1).text().endswith("a.jpg")
+    assert widget.table.item(1, 1).text().endswith("b.png")
+    assert widget.table.item(2, 1).text().endswith("c.png")
+    assert widget.table.item(0, 2).text() == "http://img/red.jpg"
+    assert widget.table.item(1, 2).text() == "http://img/blue.jpg"
+    assert widget.table.item(2, 2).text() == ""
+
+
+def test_populate_table_more_variants_than_images(tmp_path: Path):
+    (tmp_path / "only.jpg").touch()
+    widget = setup_widget(tmp_path)
+    data = {
+        "Red": "http://img/red.jpg",
+        "Blue": "http://img/blue.jpg",
+    }
+    widget.populate_table(data)
+
+    assert widget.table.rowCount() == 2
+    assert widget.table.item(1, 1).text() == ""
+    assert widget.table.item(1, 2).text() == "http://img/blue.jpg"


### PR DESCRIPTION
## Summary
- implement `CombinedScrapeWidget` to download competitor images, extract variants and build Woo links
- expose the widget through `widgets.__init__` and add as new tab in `ScrapWidget`
- document the widget in `scraping.txt`
- test the table population logic for the widget

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab9c6a4f48330a6d9e227eb34174a