### PR TITLE
Add flake8 config and style tooling

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503

--- a/MOTEUR/compta/achats/signals.py
+++ b/MOTEUR/compta/achats/signals.py
@@ -1,10 +1,11 @@
 from PySide6.QtCore import QObject, Signal
 
+
 class AchatSignals(QObject):
     """Signals emitted by the purchases module."""
 
     supplier_changed = Signal()
-    entry_changed    = Signal()
+    entry_changed = Signal()
 
 
 signals = AchatSignals()

--- a/MOTEUR/compta/achats/widget.py
+++ b/MOTEUR/compta/achats/widget.py
@@ -151,7 +151,6 @@ class AchatWidget(QWidget):
             for sid, name in conn.execute("SELECT id, name FROM suppliers"):
                 self.supplier_combo.addItem(name, sid)
 
-
     def load_expense_accounts(self) -> None:
         self.account_combo.clear()
         with connect(db_path) as conn:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: lint test check
+
+lint:
+	flake8 MOTEUR/compta/achats
+
+test:
+	QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q
+
+check: lint test

--- a/README.md
+++ b/README.md
@@ -121,6 +121,25 @@ les tests unitaires peuvent ensuite être exécutés avec **pytest** depuis la r
 
 ```bash
 PYTHONPATH=. pytest
+
+```
+
+### Vérification du style
+
+Le dépôt inclut une configuration **flake8** (`.flake8`) fixant notamment la
+longueur maximale des lignes à 100 caractères. Vous pouvez vérifier le code
+avec :
+
+```bash
+flake8
+```
+
+### Commande combinée
+
+Une cible `make check` est fournie pour lancer à la fois **flake8** et les tests :
+
+```bash
+make check
 ```
 
 ## 📤 Export FEC et TVA


### PR DESCRIPTION
## Summary
- configure flake8 rules at repo root
- clean up achat signals and widget modules to satisfy flake8
- document style check in README and add a Makefile

## Testing
- `flake8 MOTEUR/compta/achats`
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_687ad5a7e65c83309b213d520fad2b74