### PR TITLE
Improve Woo link matching by filename keyword

### DIFF
--- a/MOTEUR/scraping/scraping.txt
+++ b/MOTEUR/scraping/scraping.txt
@@ -1283,6 +1283,17 @@ from PySide6.QtWidgets import (
 
 from .scraping_widget import ScrapeWorker
 from ..scraping_variantes import extract_variants_with_images
+from ..image_scraper.constants import IMAGES_DEFAULT_SELECTOR
+from ..image_scraper.rename import clean_filename
+
+
+def find_woo_link(name: str, links: list[str]) -> str | None:
+    """Return and remove the first link whose filename contains *name*."""
+    key = clean_filename(name)
+    for idx, url in enumerate(list(links)):
+        if key and key in clean_filename(Path(url).stem):
+            return links.pop(idx)
+    return None
 
 
 class CombinedScrapeWidget(QWidget):
@@ -1314,14 +1325,25 @@ class CombinedScrapeWidget(QWidget):
 
     def populate_table(self, variants: dict[str, str]) -> None:
         woo_links = self.generate_woo_links()
+        remaining = list(woo_links)
         items = list(variants.items())
-        total = max(len(woo_links), len(items))
         self.table.setRowCount(0)
-        for i in range(total):
-            name, comp = items[i] if i < len(items) else ("", "")
-            woo = woo_links[i] if i < len(woo_links) else ""
+
+        for name, comp in items:
+            woo = find_woo_link(name, remaining)
+            if woo is None and remaining:
+                woo = remaining.pop(0)
             row = self.table.rowCount()
             self.table.insertRow(row)
             self.table.setItem(row, 0, QTableWidgetItem(name))
-            self.table.setItem(row, 1, QTableWidgetItem(woo))
+            self.table.setItem(row, 1, QTableWidgetItem(woo or ""))
             self.table.setItem(row, 2, QTableWidgetItem(comp))
+
+        for woo in remaining:
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            self.table.setItem(row, 0, QTableWidgetItem(""))
+            self.table.setItem(row, 1, QTableWidgetItem(woo))
+            self.table.setItem(row, 2, QTableWidgetItem(""))
+
+# Woo links matched to variants by keyword in file names

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Une fois l'opération terminée, un tableau rassemble les informations suivantes
 | Blue | https://shop.com/wp-content/uploads/2024/05/b.png | http://img/blue.jpg |
 |  | https://shop.com/wp-content/uploads/2024/05/c.png |  |
 
+Les liens WooCommerce sont appariés aux variantes en cherchant un mot clé
+dans le nom du fichier d'image. Par exemple, le fichier `camel.webp` sera
+automatiquement associé à la variante « Camel ».
+
 ## 🧪 Lancer les tests
 
 Après avoir installé les dépendances du projet avec :

--- a/tests/test_combined_scrape_widget.py
+++ b/tests/test_combined_scrape_widget.py
@@ -45,3 +45,21 @@ def test_populate_table_more_variants_than_images(tmp_path: Path):
     assert widget.table.rowCount() == 2
     assert widget.table.item(1, 1).text() == ""
     assert widget.table.item(1, 2).text() == "http://img/blue.jpg"
+
+
+def test_populate_table_filename_match(tmp_path: Path):
+    (tmp_path / "dog.webp").touch()
+    (tmp_path / "camel.webp").touch()
+    widget = setup_widget(tmp_path)
+    data = {
+        "Dog": "http://img/dog.jpg",
+        "Camel": "http://img/camel.jpg",
+    }
+    widget.populate_table(data)
+
+    mapping = {
+        widget.table.item(i, 0).text(): widget.table.item(i, 1).text()
+        for i in range(widget.table.rowCount())
+    }
+    assert mapping["Camel"].endswith("camel.webp")
+    assert mapping["Dog"].endswith("dog.webp")


### PR DESCRIPTION
## Summary
- import `clean_filename` and add `find_woo_link`
- match WooCommerce links to variants using filename keywords
- document keyword matching in README and scraping listing
- test that `camel.webp` is paired with `Camel` variant

## Testing
- `flake8` *(fails: command not found)*
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b919e69ac83308489278599da4b5a