### PR TITLE
Add dynamic module settings tab for scraping

### DIFF
--- a/MOTEUR/scraping/scraping.txt
+++ b/MOTEUR/scraping/scraping.txt
@@ -1347,3 +1347,31 @@ class CombinedScrapeWidget(QWidget):
             self.table.setItem(row, 2, QTableWidgetItem(""))
 
 # Woo links matched to variants by keyword in file names
+
+===== MOTEUR/scraping/widgets/settings_widget.py =====
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QCheckBox, QVBoxLayout, QWidget
+
+
+class ScrapingSettingsWidget(QWidget):
+    """Tab allowing to enable or disable scraping modules."""
+
+    module_toggled = Signal(str, bool)
+
+    def __init__(self, modules: Iterable[str], parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.checkboxes: dict[str, QCheckBox] = {}
+        for name in modules:
+            cb = QCheckBox(name)
+            cb.setChecked(True)
+            cb.toggled.connect(lambda state, n=name: self.module_toggled.emit(n, state))
+            layout.addWidget(cb)
+            self.checkboxes[name] = cb
+        layout.addStretch()
+

--- a/MOTEUR/scraping/widgets/__init__.py
+++ b/MOTEUR/scraping/widgets/__init__.py
@@ -4,4 +4,5 @@ from .variant_widget import ScrapingVariantsWidget
 from .woo_url_widget import WooImageURLWidget
 from .variant_comparison_widget import VariantComparisonWidget
 from .combined_scrape_widget import CombinedScrapeWidget
+from .settings_widget import ScrapingSettingsWidget
 from .scrap_widget import ScrapWidget

--- a/MOTEUR/scraping/widgets/scrap_widget.py
+++ b/MOTEUR/scraping/widgets/scrap_widget.py
@@ -9,6 +9,7 @@ from .variant_widget import ScrapingVariantsWidget
 from .woo_url_widget import WooImageURLWidget
 from .variant_comparison_widget import VariantComparisonWidget
 from .combined_scrape_widget import CombinedScrapeWidget
+from .settings_widget import ScrapingSettingsWidget
 
 
 class ScrapWidget(QWidget):
@@ -20,16 +21,57 @@ class ScrapWidget(QWidget):
         layout = QVBoxLayout(self)
 
         self.tabs = QTabWidget()
+
         self.images_widget = ScrapingImagesWidget()
         self.variants_widget = ScrapingVariantsWidget()
         self.woo_widget = WooImageURLWidget()
         self.compare_widget = VariantComparisonWidget()
         self.combined_widget = CombinedScrapeWidget()
 
-        self.tabs.addTab(self.images_widget, "Images")
-        self.tabs.addTab(self.variants_widget, "Variantes")
-        self.tabs.addTab(self.woo_widget, "Liens Woo")
-        self.tabs.addTab(self.compare_widget, "Comparaison")
-        self.tabs.addTab(self.combined_widget, "Tout-en-un")
+        self.modules_order = [
+            "Images",
+            "Variantes",
+            "Liens Woo",
+            "Comparaison",
+            "Tout-en-un",
+        ]
+
+        self.modules = {
+            "Images": self.images_widget,
+            "Variantes": self.variants_widget,
+            "Liens Woo": self.woo_widget,
+            "Comparaison": self.compare_widget,
+            "Tout-en-un": self.combined_widget,
+        }
+
+        for name in self.modules_order:
+            self.tabs.addTab(self.modules[name], name)
+
+        self.settings_widget = ScrapingSettingsWidget(self.modules_order)
+        self.settings_widget.module_toggled.connect(self.toggle_module)
+        self.tabs.addTab(self.settings_widget, "Paramètres")
 
         layout.addWidget(self.tabs)
+
+    # ------------------------------------------------------------------
+    def toggle_module(self, name: str, enabled: bool) -> None:
+        """Show or hide the tab corresponding to *name*."""
+        widget = self.modules.get(name)
+        if not widget:
+            return
+        current_index = self.tabs.indexOf(widget)
+        if enabled and current_index == -1:
+            param_index = self.tabs.indexOf(self.settings_widget)
+            pos = 0
+            for n in self.modules_order:
+                if n == name:
+                    break
+                if self.tabs.indexOf(self.modules[n]) != -1:
+                    pos += 1
+            self.tabs.insertTab(pos, widget, name)
+            if pos <= param_index:
+                # keep settings tab last
+                self.tabs.removeTab(self.tabs.indexOf(self.settings_widget))
+                self.tabs.addTab(self.settings_widget, "Paramètres")
+        elif not enabled and current_index != -1:
+            self.tabs.removeTab(current_index)

--- a/MOTEUR/scraping/widgets/settings_widget.py
+++ b/MOTEUR/scraping/widgets/settings_widget.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QCheckBox, QVBoxLayout, QWidget
+
+
+class ScrapingSettingsWidget(QWidget):
+    """Tab allowing to enable or disable scraping modules."""
+
+    module_toggled = Signal(str, bool)
+
+    def __init__(self, modules: Iterable[str], parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.checkboxes: dict[str, QCheckBox] = {}
+        for name in modules:
+            cb = QCheckBox(name)
+            cb.setChecked(True)
+            cb.toggled.connect(lambda state, n=name: self.module_toggled.emit(n, state))
+            layout.addWidget(cb)
+            self.checkboxes[name] = cb
+        layout.addStretch()


### PR DESCRIPTION
## Summary
- add `ScrapingSettingsWidget` with checkboxes for each scraping module
- integrate settings tab in `ScrapWidget` to toggle other tabs
- export `ScrapingSettingsWidget` and update scraping module reference
- update textual listing `scraping.txt`

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_687b9868cf788330b693d44bf3855b7d