### PR TITLE
Move scraping settings to separate sidebar page

### DIFF
--- a/MOTEUR/scraping/widgets/scrap_widget.py
+++ b/MOTEUR/scraping/widgets/scrap_widget.py
@@ -9,7 +9,6 @@ from .variant_widget import ScrapingVariantsWidget
 from .woo_url_widget import WooImageURLWidget
 from .variant_comparison_widget import VariantComparisonWidget
 from .combined_scrape_widget import CombinedScrapeWidget
-from .settings_widget import ScrapingSettingsWidget
 
 
 class ScrapWidget(QWidget):
@@ -47,9 +46,7 @@ class ScrapWidget(QWidget):
         for name in self.modules_order:
             self.tabs.addTab(self.modules[name], name)
 
-        self.settings_widget = ScrapingSettingsWidget(self.modules_order)
-        self.settings_widget.module_toggled.connect(self.toggle_module)
-        self.tabs.addTab(self.settings_widget, "Paramètres")
+        # Settings widget will be handled externally
 
         layout.addWidget(self.tabs)
 
@@ -61,7 +58,6 @@ class ScrapWidget(QWidget):
             return
         current_index = self.tabs.indexOf(widget)
         if enabled and current_index == -1:
-            param_index = self.tabs.indexOf(self.settings_widget)
             pos = 0
             for n in self.modules_order:
                 if n == name:
@@ -69,9 +65,5 @@ class ScrapWidget(QWidget):
                 if self.tabs.indexOf(self.modules[n]) != -1:
                     pos += 1
             self.tabs.insertTab(pos, widget, name)
-            if pos <= param_index:
-                # keep settings tab last
-                self.tabs.removeTab(self.tabs.indexOf(self.settings_widget))
-                self.tabs.addTab(self.settings_widget, "Paramètres")
         elif not enabled and current_index != -1:
             self.tabs.removeTab(current_index)

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ except ModuleNotFoundError:
     sys.exit(1)
 
 from MOTEUR.scraping.widgets.scrap_widget import ScrapWidget
+from MOTEUR.scraping.widgets.settings_widget import ScrapingSettingsWidget
 from MOTEUR.compta.achats.widget import AchatWidget
 from MOTEUR.compta.ventes.widget import VenteWidget
 from MOTEUR.compta.accounting.widget import AccountWidget
@@ -273,6 +274,16 @@ class MainWindow(QMainWindow):
         )
         scrap_section.add_widget(btn)
         self.button_group.append(btn)
+
+        self.scrap_settings_btn = SidebarButton(
+            "Param\u00e8tres Scraping",
+            icon_path=str(BASE_DIR / "icons" / "settings.svg"),
+        )
+        self.scrap_settings_btn.clicked.connect(
+            lambda _, b=self.scrap_settings_btn: self.show_scraping_settings_page(b)
+        )
+        scrap_section.add_widget(self.scrap_settings_btn)
+        self.button_group.append(self.scrap_settings_btn)
         nav_layout.addWidget(scrap_section)
 
         nav_layout.addStretch()
@@ -305,6 +316,15 @@ class MainWindow(QMainWindow):
         # Page regrouping scraping images and variants
         self.scrap_page = ScrapWidget()
         self.stack.addWidget(self.scrap_page)
+
+        # Settings page for scraping modules
+        self.scraping_settings_page = ScrapingSettingsWidget(
+            self.scrap_page.modules_order
+        )
+        self.scraping_settings_page.module_toggled.connect(
+            self.scrap_page.toggle_module
+        )
+        self.stack.addWidget(self.scraping_settings_page)
 
         self.profile_page.profile_chosen.connect(
             self.scrap_page.images_widget.set_selected_profile
@@ -458,6 +478,12 @@ class MainWindow(QMainWindow):
         self.clear_selection()
         button.setChecked(True)
         self.stack.setCurrentWidget(self.suppliers_page)
+
+    def show_scraping_settings_page(self, button: SidebarButton) -> None:
+        """Display the scraping settings page."""
+        self.clear_selection()
+        button.setChecked(True)
+        self.stack.setCurrentWidget(self.scraping_settings_page)
 
     def show_ventes_page(self, button: SidebarButton) -> None:
         """Display the ventes page."""


### PR DESCRIPTION
## Summary
- remove settings tab from `ScrapWidget`
- add dedicated Scraping Settings page accessible from sidebar
- connect settings to toggle modules inside ScrapWidget

## Testing
- `flake8` *(fails: F401 E302 etc.)*
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b9c295c088330b974977074522517