### PR TITLE
Fix variant link matching with hyphens

### DIFF
--- a/MOTEUR/scraping/image_scraper/rename.py
+++ b/MOTEUR/scraping/image_scraper/rename.py
@@ -38,8 +38,8 @@ def clean_filename(text: str) -> str:
     normalized = unicodedata.normalize("NFD", text)
     ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
     ascii_text = ascii_text.lower()
-    ascii_text = re.sub(r"\s+", "_", ascii_text)
-    ascii_text = re.sub(r"[^a-z0-9_-]", "", ascii_text)
+    ascii_text = re.sub(r"[\s-]+", "_", ascii_text)
+    ascii_text = re.sub(r"[^a-z0-9_]", "", ascii_text)
     return ascii_text
 
 

--- a/tests/test_combined_scrape_widget.py
+++ b/tests/test_combined_scrape_widget.py
@@ -70,3 +70,18 @@ def test_populate_table_filename_match(tmp_path: Path):
     }
     assert mapping["Camel"].endswith("camel.webp")
     assert mapping["Dog"].endswith("dog.webp")
+
+
+def test_populate_table_hyphen_and_space_match(tmp_path: Path):
+    (tmp_path / "bob-bleu-ciel.webp").touch()
+    (tmp_path / "bob-vert-clair.webp").touch()
+    widget = setup_widget(tmp_path)
+    data = {"Bleu ciel": "foo", "Vert clair": "bar"}
+    widget.populate_table(data)
+
+    mapping = {
+        widget.table.item(i, 0).text(): widget.table.item(i, 1).text()
+        for i in range(widget.table.rowCount())
+    }
+    assert mapping["Bleu ciel"].endswith("bob-bleu-ciel.webp")
+    assert mapping["Vert clair"].endswith("bob-vert-clair.webp")


### PR DESCRIPTION
## Summary
- normalize hyphens when cleaning image names
- test that hyphenated filenames match variants with spaces

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba61793f4833098d7c52223cfb262