### PR TITLE
Add CSV export in combined widget

### DIFF
--- a/MOTEUR/scraping/scraping.txt
+++ b/MOTEUR/scraping/scraping.txt
@@ -1366,6 +1366,23 @@ class CombinedScrapeWidget(QWidget):
             self.table.setItem(row, 1, QTableWidgetItem(woo))
             self.table.setItem(row, 2, QTableWidgetItem(""))
 
+    def export_csv(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Exporter CSV", str(Path.home()), "CSV (*.csv)"
+        )
+        if not path:
+            return
+        with open(path, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["Variante", "Lien Woo"])
+            for i in range(self.table.rowCount()):
+                var = self.table.item(i, 0)
+                woo = self.table.item(i, 1)
+                writer.writerow([
+                    var.text() if var else "",
+                    woo.text() if woo else "",
+                ])
+
 # Woo links matched to variants by keyword in file names
 
 ===== MOTEUR/scraping/widgets/settings_widget.py =====

--- a/MOTEUR/scraping/widgets/combined_scrape_widget.py
+++ b/MOTEUR/scraping/widgets/combined_scrape_widget.py
@@ -19,6 +19,7 @@ from PySide6.QtWidgets import (
     QTextEdit,
     QComboBox,
 )
+import csv
 
 from .scraping_widget import ScrapeWorker
 from ..scraping_variantes import extract_variants_with_images
@@ -89,6 +90,13 @@ class CombinedScrapeWidget(QWidget):
         self.table.horizontalHeader().setStretchLastSection(True)
         layout.addWidget(self.table)
 
+        btn_row = QHBoxLayout()
+        export_btn = QPushButton("Exporter CSV")
+        export_btn.clicked.connect(self.export_csv)
+        btn_row.addStretch()
+        btn_row.addWidget(export_btn)
+        layout.addLayout(btn_row)
+
         self.scrape_folder: Path | None = None
         self.worker: ScrapeWorker | None = None
         self.domain: str = ""
@@ -135,6 +143,23 @@ class CombinedScrapeWidget(QWidget):
             self.table.setItem(row, 0, QTableWidgetItem(""))
             self.table.setItem(row, 1, QTableWidgetItem(woo))
             self.table.setItem(row, 2, QTableWidgetItem(""))
+
+    def export_csv(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Exporter CSV", str(Path.home()), "CSV (*.csv)"
+        )
+        if not path:
+            return
+        with open(path, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(["Variante", "Lien Woo"])
+            for row in range(self.table.rowCount()):
+                var_item = self.table.item(row, 0)
+                woo_item = self.table.item(row, 1)
+                writer.writerow([
+                    var_item.text() if var_item else "",
+                    woo_item.text() if woo_item else "",
+                ])
 
     @Slot()
     def start_process(self) -> None:

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Les liens WooCommerce sont appariés aux variantes en cherchant un mot clé
 dans le nom du fichier d'image. Par exemple, le fichier `camel.webp` sera
 automatiquement associé à la variante « Camel ».
 
+Un bouton « Exporter CSV » permet d'enregistrer les couples Variante/Lien Woo
+dans un fichier pour une utilisation ultérieure.
+
 ## 🧪 Lancer les tests
 
 Après avoir installé les dépendances du projet avec :

--- a/tests/test_combined_scrape_widget.py
+++ b/tests/test_combined_scrape_widget.py
@@ -85,3 +85,28 @@ def test_populate_table_hyphen_and_space_match(tmp_path: Path):
     }
     assert mapping["Bleu ciel"].endswith("bob-bleu-ciel.webp")
     assert mapping["Vert clair"].endswith("bob-vert-clair.webp")
+
+
+def test_export_csv(tmp_path: Path, monkeypatch):
+    widget = setup_widget(tmp_path)
+    widget.table.setRowCount(0)
+    widget.table.insertRow(0)
+    widget.table.setItem(0, 0, QTableWidgetItem("Red"))
+    widget.table.setItem(0, 1, QTableWidgetItem("https://shop.com/red.jpg"))
+
+    dest = tmp_path / "out.csv"
+
+    def fake_get_save(parent, title, d, filt):
+        return str(dest), "CSV (*.csv)"
+
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.combined_scrape_widget.QFileDialog.getSaveFileName",
+        fake_get_save,
+    )
+
+    widget.export_csv()
+
+    with dest.open() as fh:
+        lines = [l.strip() for l in fh]
+
+    assert lines == ["Variante,Lien Woo", "Red,https://shop.com/red.jpg"]


### PR DESCRIPTION
## Summary
- add an Exporter CSV button to CombinedScrapeWidget
- implement export_csv method
- document new feature
- update text spec
- test the CSV export

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_687bb010b86c8330a11bfef238f73b51