### PR TITLE
Add URL file field for scraping profiles

### DIFF
--- a/MOTEUR/scraping/profiles/manager.py
+++ b/MOTEUR/scraping/profiles/manager.py
@@ -15,6 +15,7 @@ class Profile:
     css_selector: str
     domain: str = "https://www.planetebob.fr"
     date: str = "2025/07"
+    url_file: str = ""
 
 
 class ProfileManager:
@@ -45,6 +46,7 @@ class ProfileManager:
                                 v.get("css", IMAGES_DEFAULT_SELECTOR),
                                 v.get("domain", "https://www.planetebob.fr"),
                                 v.get("date", "2025/07"),
+                                v.get("url_file", ""),
                             )
                 else:
                     self.profiles = {}
@@ -63,6 +65,7 @@ class ProfileManager:
                         "css": p.css_selector,
                         "domain": p.domain,
                         "date": p.date,
+                        "url_file": p.url_file,
                     }
                     for name, p in self.profiles.items()
                 },
@@ -75,9 +78,11 @@ class ProfileManager:
         """Return the profile for *name* if present."""
         return self.profiles.get(name)
 
-    def add_or_update_profile(self, name: str, css: str, domain: str, date: str) -> None:
+    def add_or_update_profile(
+        self, name: str, css: str, domain: str, date: str, url_file: str = ""
+    ) -> None:
         """Add or update *name* with profile parameters and persist it."""
-        self.profiles[name] = Profile(css, domain, date)
+        self.profiles[name] = Profile(css, domain, date, url_file)
         self.save_profiles()
 
     def remove_profile(self, name: str) -> None:

--- a/MOTEUR/scraping/scraping.txt
+++ b/MOTEUR/scraping/scraping.txt
@@ -622,6 +622,7 @@ class Profile:
     css_selector: str
     domain: str = "https://www.planetebob.fr"
     date: str = "2025/07"
+    url_file: str = ""
 
 
 class ProfileManager:
@@ -652,6 +653,7 @@ class ProfileManager:
                                 v.get("css", IMAGES_DEFAULT_SELECTOR),
                                 v.get("domain", "https://www.planetebob.fr"),
                                 v.get("date", "2025/07"),
+                                v.get("url_file", ""),
                             )
                 else:
                     self.profiles = {}
@@ -670,6 +672,7 @@ class ProfileManager:
                         "css": p.css_selector,
                         "domain": p.domain,
                         "date": p.date,
+                        "url_file": p.url_file,
                     }
                     for name, p in self.profiles.items()
                 },
@@ -682,9 +685,11 @@ class ProfileManager:
         """Return the profile for *name* if present."""
         return self.profiles.get(name)
 
-    def add_or_update_profile(self, name: str, css: str, domain: str, date: str) -> None:
+    def add_or_update_profile(
+        self, name: str, css: str, domain: str, date: str, url_file: str = ""
+    ) -> None:
         """Add or update *name* with profile parameters and persist it."""
-        self.profiles[name] = Profile(css, domain, date)
+        self.profiles[name] = Profile(css, domain, date, url_file)
         self.save_profiles()
 
     def remove_profile(self, name: str) -> None:
@@ -780,10 +785,13 @@ class ProfileWidget(QWidget):
             QMessageBox.warning(self, "Profil", "Nom manquant")
             return
         css = self.css_edit.text().strip()
+        domain = self.domain_edit.text().strip()
+        date = self.date_edit.text().strip()
+        url_file = self.url_file_edit.text().strip()
         if name in self.manager.profiles:
             QMessageBox.information(self, "Profil", "Ce profil existe déjà")
             return
-        self.manager.add_or_update_profile(name, css)
+        self.manager.add_or_update_profile(name, css, domain, date, url_file)
         self.profile_list.addItem(name)
         self.profile_list.setCurrentRow(self.profile_list.count() - 1)
 
@@ -793,7 +801,10 @@ class ProfileWidget(QWidget):
             QMessageBox.warning(self, "Profil", "Nom manquant")
             return
         css = self.css_edit.text().strip()
-        self.manager.add_or_update_profile(name, css)
+        domain = self.domain_edit.text().strip()
+        date = self.date_edit.text().strip()
+        url_file = self.url_file_edit.text().strip()
+        self.manager.add_or_update_profile(name, css, domain, date, url_file)
         # Ensure the list has this profile
         for i in range(self.profile_list.count()):
             if self.profile_list.item(i).text() == name:
@@ -818,6 +829,9 @@ class ProfileWidget(QWidget):
                 break
         self.name_edit.clear()
         self.css_edit.clear()
+        self.domain_edit.clear()
+        self.date_edit.clear()
+        self.url_file_edit.clear()
         if self.profile_list.count():
             self.profile_list.setCurrentRow(0)
 

--- a/MOTEUR/scraping/widgets/combined_scrape_widget.py
+++ b/MOTEUR/scraping/widgets/combined_scrape_widget.py
@@ -164,10 +164,16 @@ class CombinedScrapeWidget(QWidget):
     @Slot()
     def start_process(self) -> None:
         url = self.url_edit.text().strip()
-        if not url:
-            return
         profile_name = self.profile_combo.currentText()
         profile = self.profile_manager.get_profile(profile_name)
+        if not url and profile and profile.url_file:
+            try:
+                url = Path(profile.url_file).read_text(encoding="utf-8").strip()
+                self.url_edit.setText(url)
+            except Exception:
+                url = ""
+        if not url:
+            return
         css = profile.css_selector if profile else IMAGES_DEFAULT_SELECTOR
         self.domain = profile.domain if profile else "https://www.planetebob.fr"
         self.date = profile.date if profile else "2025/07"
@@ -218,9 +224,18 @@ class CombinedScrapeWidget(QWidget):
         self.profile_manager = ProfileManager()
         self.profile_combo.clear()
         self.profile_combo.addItems(sorted(self.profile_manager.profiles))
+        if self.profile_combo.count():
+            self.set_selected_profile(self.profile_combo.currentText())
 
     @Slot(str)
     def set_selected_profile(self, name: str) -> None:
         index = self.profile_combo.findText(name)
         if index >= 0:
             self.profile_combo.setCurrentIndex(index)
+        profile = self.profile_manager.get_profile(name)
+        if profile and profile.url_file:
+            try:
+                url = Path(profile.url_file).read_text(encoding="utf-8").strip()
+                self.url_edit.setText(url)
+            except Exception:
+                pass

--- a/MOTEUR/scraping/widgets/profile_widget.py
+++ b/MOTEUR/scraping/widgets/profile_widget.py
@@ -52,6 +52,10 @@ class ProfileWidget(QWidget):
         self.date_edit.setPlaceholderText("Date YYYY/MM")
         form_layout.addWidget(self.date_edit)
 
+        self.url_file_edit = QLineEdit()
+        self.url_file_edit.setPlaceholderText("Fichier URL")
+        form_layout.addWidget(self.url_file_edit)
+
         main_layout.addLayout(form_layout)
 
         # Buttons
@@ -84,6 +88,7 @@ class ProfileWidget(QWidget):
             self.css_edit.setText(css)
             self.domain_edit.setText(profile.domain if profile else "")
             self.date_edit.setText(profile.date if profile else "")
+            self.url_file_edit.setText(profile.url_file if profile else "")
 
     def add_profile(self) -> None:
         name = self.name_edit.text().strip()
@@ -93,10 +98,11 @@ class ProfileWidget(QWidget):
         css = self.css_edit.text().strip()
         domain = self.domain_edit.text().strip()
         date = self.date_edit.text().strip()
+        url_file = self.url_file_edit.text().strip()
         if name in self.manager.profiles:
             QMessageBox.information(self, "Profil", "Ce profil existe déjà")
             return
-        self.manager.add_or_update_profile(name, css, domain, date)
+        self.manager.add_or_update_profile(name, css, domain, date, url_file)
         self.profile_list.addItem(name)
         self.profile_list.setCurrentRow(self.profile_list.count() - 1)
         self.profiles_updated.emit()
@@ -109,7 +115,8 @@ class ProfileWidget(QWidget):
         css = self.css_edit.text().strip()
         domain = self.domain_edit.text().strip()
         date = self.date_edit.text().strip()
-        self.manager.add_or_update_profile(name, css, domain, date)
+        url_file = self.url_file_edit.text().strip()
+        self.manager.add_or_update_profile(name, css, domain, date, url_file)
         # Ensure the list has this profile
         for i in range(self.profile_list.count()):
             if self.profile_list.item(i).text() == name:
@@ -137,6 +144,7 @@ class ProfileWidget(QWidget):
         self.css_edit.clear()
         self.domain_edit.clear()
         self.date_edit.clear()
+        self.url_file_edit.clear()
         if self.profile_list.count():
             self.profile_list.setCurrentRow(0)
         self.profiles_updated.emit()

--- a/tests/test_combined_scrape_widget.py
+++ b/tests/test_combined_scrape_widget.py
@@ -10,7 +10,7 @@ def setup_widget(tmp_path: Path) -> CombinedScrapeWidget:
     widget = CombinedScrapeWidget()
     widget.scrape_folder = tmp_path
     widget.profile_manager.profiles["test"] = Profile(
-        "img", "https://shop.com", "2024/05"
+        "img", "https://shop.com", "2024/05", ""
     )
     widget.profile_combo.clear()
     widget.profile_combo.addItem("test")
@@ -110,3 +110,16 @@ def test_export_csv(tmp_path: Path, monkeypatch):
         lines = [l.strip() for l in fh]
 
     assert lines == ["Variante,Lien Woo", "Red,https://shop.com/red.jpg"]
+
+
+def test_profile_url_loaded(tmp_path: Path):
+    url_file = tmp_path / "url.txt"
+    url_file.write_text("http://example.com")
+    widget = setup_widget(tmp_path)
+    widget.profile_manager.profiles["file"] = Profile(
+        "img", "https://shop.com", "2024/05", str(url_file)
+    )
+    widget.profile_combo.addItem("file")
+    widget.set_selected_profile("file")
+
+    assert widget.url_edit.text() == "http://example.com"

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -40,6 +40,7 @@ def test_default_profile_creation(tmp_path: Path) -> None:
             "css": IMAGES_DEFAULT_SELECTOR,
             "domain": "https://www.planetebob.fr",
             "date": "2025/07",
+            "url_file": "",
         }
     }
 


### PR DESCRIPTION
## Summary
- allow profiles to store a `url_file`
- load the competitor URL from this file in the combined scraper widget
- expose the new field in `ProfileWidget`
- adjust tests and reference docs

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_687bb3a6b70c833087089f6641f64653