### PR TITLE
Add profile file picker and competitor link toggle

### DIFF
--- a/MOTEUR/scraping/widgets/profile_widget.py
+++ b/MOTEUR/scraping/widgets/profile_widget.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Optional
+from pathlib import Path
 
 from PySide6.QtWidgets import (
     QWidget,
@@ -10,6 +11,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QPushButton,
     QMessageBox,
+    QFileDialog,
 )
 from PySide6.QtCore import Signal
 
@@ -52,9 +54,14 @@ class ProfileWidget(QWidget):
         self.date_edit.setPlaceholderText("Date YYYY/MM")
         form_layout.addWidget(self.date_edit)
 
+        url_container = QHBoxLayout()
         self.url_file_edit = QLineEdit()
         self.url_file_edit.setPlaceholderText("Fichier URL")
-        form_layout.addWidget(self.url_file_edit)
+        url_container.addWidget(self.url_file_edit)
+        self.url_file_btn = QPushButton("...")
+        self.url_file_btn.clicked.connect(self.select_url_file)
+        url_container.addWidget(self.url_file_btn)
+        form_layout.addLayout(url_container)
 
         main_layout.addLayout(form_layout)
 
@@ -154,3 +161,14 @@ class ProfileWidget(QWidget):
         name = self.name_edit.text().strip()
         if name:
             self.profile_chosen.emit(name)
+
+    def select_url_file(self) -> None:
+        """Open a file dialog to select a text file containing URLs."""
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Choisir un fichier",
+            str(Path.home()),
+            "Text files (*.txt);;All files (*)",
+        )
+        if path:
+            self.url_file_edit.setText(path)

--- a/MOTEUR/scraping/widgets/settings_widget.py
+++ b/MOTEUR/scraping/widgets/settings_widget.py
@@ -10,6 +10,7 @@ class ScrapingSettingsWidget(QWidget):
     """Tab allowing to enable or disable scraping modules."""
 
     module_toggled = Signal(str, bool)
+    comp_links_toggled = Signal(bool)
 
     def __init__(self, modules: Iterable[str], parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -21,4 +22,9 @@ class ScrapingSettingsWidget(QWidget):
             cb.toggled.connect(lambda state, n=name: self.module_toggled.emit(n, state))
             layout.addWidget(cb)
             self.checkboxes[name] = cb
+
+        self.comp_links_cb = QCheckBox("Lien produits concurrent")
+        self.comp_links_cb.setChecked(True)
+        self.comp_links_cb.toggled.connect(lambda s: self.comp_links_toggled.emit(s))
+        layout.addWidget(self.comp_links_cb)
         layout.addStretch()

--- a/main.py
+++ b/main.py
@@ -324,6 +324,9 @@ class MainWindow(QMainWindow):
         self.scraping_settings_page.module_toggled.connect(
             self.scrap_page.toggle_module
         )
+        self.scraping_settings_page.comp_links_toggled.connect(
+            self.scrap_page.combined_widget.toggle_comp_links
+        )
         self.stack.addWidget(self.scraping_settings_page)
 
         self.profile_page.profile_chosen.connect(

--- a/tests/test_combined_scrape_widget.py
+++ b/tests/test_combined_scrape_widget.py
@@ -123,3 +123,12 @@ def test_profile_url_loaded(tmp_path: Path):
     widget.set_selected_profile("file")
 
     assert widget.url_edit.text() == "http://example.com"
+
+
+def test_toggle_comp_links_visibility():
+    app = QApplication.instance() or QApplication([])
+    widget = CombinedScrapeWidget()
+    widget.toggle_comp_links(False)
+    assert widget.url_edit.isHidden()
+    widget.toggle_comp_links(True)
+    assert not widget.url_edit.isHidden()

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -141,3 +141,29 @@ def test_profile_widget_updates_scraping_widget(tmp_path: Path, monkeypatch) -> 
 
     items = [scrap_w.profile_combo.itemText(i) for i in range(scrap_w.profile_combo.count())]
     assert "new" in items
+
+
+def test_url_file_browse_sets_path(tmp_path: Path, monkeypatch) -> None:
+    import os
+    os.environ["QT_QPA_PLATFORM"] = "offscreen"
+    app = QApplication.instance() or QApplication([])
+
+    json_path = tmp_path / "profiles.json"
+    monkeypatch.setattr(pw, "ProfileManager", lambda *a, **k: ProfileManager(json_path))
+
+    widget = pw.ProfileWidget()
+
+    dest = tmp_path / "links.txt"
+    dest.write_text("http://example.com")
+
+    def fake_open(parent, title, d, filt):
+        return str(dest), "Text files (*.txt)"
+
+    monkeypatch.setattr(
+        "MOTEUR.scraping.widgets.profile_widget.QFileDialog.getOpenFileName",
+        fake_open,
+    )
+
+    widget.select_url_file()
+
+    assert widget.url_file_edit.text() == str(dest)


### PR DESCRIPTION
## Summary
- add a file selection button for profile URL files
- allow toggling competitor URL feature from scraping settings
- connect new setting with the combined scraper
- update tests for new widgets

## Testing
- `QT_QPA_PLATFORM=offscreen python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb7f6f49c83308abbb71c1fe836f7