### PR TITLE
Fix URL reading for combined widget

### DIFF
--- a/MOTEUR/scraping/widgets/combined_scrape_widget.py
+++ b/MOTEUR/scraping/widgets/combined_scrape_widget.py
@@ -174,7 +174,8 @@ class CombinedScrapeWidget(QWidget):
         profile = self.profile_manager.get_profile(profile_name)
         if self.comp_links_enabled and not url and profile and profile.url_file:
             try:
-                url = Path(profile.url_file).read_text(encoding="utf-8").strip()
+                # UTF-8 with BOM is accepted; read_text("utf-8-sig") strips it
+                url = Path(profile.url_file).read_text(encoding="utf-8-sig").strip()
                 self.url_edit.setText(url)
             except Exception:
                 url = ""
@@ -247,7 +248,8 @@ class CombinedScrapeWidget(QWidget):
         profile = self.profile_manager.get_profile(name)
         if profile and profile.url_file:
             try:
-                url = Path(profile.url_file).read_text(encoding="utf-8").strip()
+                # Handle optional BOM from Windows editors
+                url = Path(profile.url_file).read_text(encoding="utf-8-sig").strip()
                 self.url_edit.setText(url)
             except Exception:
                 pass


### PR DESCRIPTION
## Summary
- handle BOM when reading profile URLs in the combined scrape widget

## Testing
- `pip install -r requirements.txt`
- `export QT_QPA_PLATFORM=offscreen && PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bbf7f05d88330b330e65907f75835