### PR TITLE
Update scraping workflow with profile URL files

### DIFF
--- a/MOTEUR/scraping/widgets/settings_widget.py
+++ b/MOTEUR/scraping/widgets/settings_widget.py
@@ -10,7 +10,6 @@ class ScrapingSettingsWidget(QWidget):
     """Tab allowing to enable or disable scraping modules."""
 
     module_toggled = Signal(str, bool)
-    comp_links_toggled = Signal(bool)
 
     def __init__(self, modules: Iterable[str], parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -23,8 +22,4 @@ class ScrapingSettingsWidget(QWidget):
             layout.addWidget(cb)
             self.checkboxes[name] = cb
 
-        self.comp_links_cb = QCheckBox("Lien produits concurrent")
-        self.comp_links_cb.setChecked(True)
-        self.comp_links_cb.toggled.connect(lambda s: self.comp_links_toggled.emit(s))
-        layout.addWidget(self.comp_links_cb)
         layout.addStretch()

--- a/liens/LIENS bob crew.txt
+++ b/liens/LIENS bob crew.txt
@@ -1,0 +1,2 @@
+https://bob-crew.com/products/bob-tissu-eponge
+https://bob-crew.com/products/bob-avec-lacet

--- a/main.py
+++ b/main.py
@@ -324,9 +324,6 @@ class MainWindow(QMainWindow):
         self.scraping_settings_page.module_toggled.connect(
             self.scrap_page.toggle_module
         )
-        self.scraping_settings_page.comp_links_toggled.connect(
-            self.scrap_page.combined_widget.toggle_comp_links
-        )
         self.stack.addWidget(self.scraping_settings_page)
 
         self.profile_page.profile_chosen.connect(

--- a/tests/test_combined_scrape_widget.py
+++ b/tests/test_combined_scrape_widget.py
@@ -112,23 +112,3 @@ def test_export_csv(tmp_path: Path, monkeypatch):
     assert lines == ["Variante,Lien Woo", "Red,https://shop.com/red.jpg"]
 
 
-def test_profile_url_loaded(tmp_path: Path):
-    url_file = tmp_path / "url.txt"
-    url_file.write_text("http://example.com")
-    widget = setup_widget(tmp_path)
-    widget.profile_manager.profiles["file"] = Profile(
-        "img", "https://shop.com", "2024/05", str(url_file)
-    )
-    widget.profile_combo.addItem("file")
-    widget.set_selected_profile("file")
-
-    assert widget.url_edit.text() == "http://example.com"
-
-
-def test_toggle_comp_links_visibility():
-    app = QApplication.instance() or QApplication([])
-    widget = CombinedScrapeWidget()
-    widget.toggle_comp_links(False)
-    assert widget.url_edit.isHidden()
-    widget.toggle_comp_links(True)
-    assert not widget.url_edit.isHidden()


### PR DESCRIPTION
## Summary
- remove competitor URL input and read all URLs from the profile file
- drop the "lien produits concurrent" checkbox from scraping settings
- adjust main window for the new scraping settings API
- simplify tests for the combined scraping widget
- add example links file under `liens/`

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bcaa468608330a17738035ba05cbb