### PR TITLE
Fix trailing numbers in downloaded image names

### DIFF
--- a/MOTEUR/scraping/image_scraper/download.py
+++ b/MOTEUR/scraping/image_scraper/download.py
@@ -104,8 +104,8 @@ def handle_image(
         src = "https:" + src
 
     raw_filename = os.path.basename(src.split("?")[0])
-    filename = re.sub(r"-\d+(?=\.\w+$)", "", raw_filename)
-    base, ext = os.path.splitext(filename)
+    base, ext = os.path.splitext(raw_filename)
+    base = re.sub(r"-?\d+$", "", base)
     base = re.sub(r"\d+", "", base)
     filename = f"{base}{ext}"
     target = unique_path(folder, filename, reserved)

--- a/MOTEUR/scraping/scraping.txt
+++ b/MOTEUR/scraping/scraping.txt
@@ -155,8 +155,8 @@ def handle_image(
         src = "https:" + src
 
     raw_filename = os.path.basename(src.split("?")[0])
-    filename = re.sub(r"-\d+(?=\.\w+$)", "", raw_filename)
-    base, ext = os.path.splitext(filename)
+    base, ext = os.path.splitext(raw_filename)
+    base = re.sub(r"-?\d+$", "", base)
     base = re.sub(r"\d+", "", base)
     filename = f"{base}{ext}"
     target = unique_path(folder, filename, reserved)

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -51,6 +51,19 @@ def test_handle_image_strips_digits(tmp_path: Path) -> None:
     assert path.name == "bob-tissu-eponge-blanc.jpg"
 
 
+def test_handle_image_no_ext(tmp_path: Path) -> None:
+    elem = DummyElement(
+        {
+            "src": "https://example.com/bob-tissu-eponge-blanc-451",
+            "naturalWidth": "300",
+            "naturalHeight": "300",
+        }
+    )
+    path, url = handle_image(elem, tmp_path, 1, USER_AGENT, set())
+    assert url == "https://example.com/bob-tissu-eponge-blanc-451"
+    assert path.name == "bob-tissu-eponge-blanc"
+
+
 def test_retry_on_stale() -> None:
     class Obj:
         def __init__(self):


### PR DESCRIPTION
## Summary
- clean image filenames even when no extension is present
- document the new logic in scraping.txt
- test handle_image with extensionless filename

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_687e23a77934833081243b96c05b0079