### PR TITLE
Add rename checkbox setting

### DIFF
--- a/MOTEUR/scraping/profiles/manager.py
+++ b/MOTEUR/scraping/profiles/manager.py
@@ -38,6 +38,7 @@ class Profile:
     domain: str = "https://www.planetebob.fr"
     date: str = "2025/07"
     url_file: str = ""
+    rename: bool = True
 
 
 class ProfileManager:
@@ -69,6 +70,7 @@ class ProfileManager:
                                 v.get("domain", "https://www.planetebob.fr"),
                                 v.get("date", "2025/07"),
                                 v.get("url_file", ""),
+                                v.get("rename", True),
                             )
                 else:
                     self.profiles = {}
@@ -88,6 +90,7 @@ class ProfileManager:
                         "domain": p.domain,
                         "date": p.date,
                         "url_file": p.url_file,
+                        "rename": p.rename,
                     }
                     for name, p in self.profiles.items()
                 },
@@ -104,10 +107,22 @@ class ProfileManager:
         return prof
 
     def add_or_update_profile(
-        self, name: str, css: str, domain: str, date: str, url_file: str = ""
+        self,
+        name: str,
+        css: str,
+        domain: str,
+        date: str,
+        url_file: str = "",
+        rename: bool = True,
     ) -> None:
         """Add or update *name* with profile parameters and persist it."""
-        self.profiles[name] = Profile(fix_css_selector(css), domain, date, url_file)
+        self.profiles[name] = Profile(
+            fix_css_selector(css),
+            domain,
+            date,
+            url_file,
+            rename,
+        )
         self.save_profiles()
 
     def remove_profile(self, name: str) -> None:

--- a/MOTEUR/scraping/widgets/combined_scrape_widget.py
+++ b/MOTEUR/scraping/widgets/combined_scrape_widget.py
@@ -111,6 +111,12 @@ class CombinedScrapeWidget(QWidget):
         self.worker: ScrapeWorker | None = None
         self.domain: str = ""
         self.date: str = ""
+        self.rename_enabled: bool = True
+
+    # ------------------------------------------------------------------
+    def set_rename_enabled(self, enabled: bool) -> None:
+        """Enable or disable filename renaming."""
+        self.rename_enabled = enabled
 
     # ------------------------------------------------------------------
     def valid_date(self, text: str) -> bool:
@@ -196,6 +202,7 @@ class CombinedScrapeWidget(QWidget):
         self.domain = profile.domain if profile else "https://www.planetebob.fr"
         self.date = profile.date if profile else "2025/07"
         self.folder = self.folder_edit.text().strip() or "images"
+        self.rename_enabled = profile.rename if profile else True
 
         self.console.clear()
         self.console.append(f"Profil: {profile_name}")
@@ -211,7 +218,12 @@ class CombinedScrapeWidget(QWidget):
         url = self.pending_urls.pop(0)
         self.current_url = url
         self.console.append(url)
-        self.worker = ScrapeWorker(url, self.css, self.folder)
+        self.worker = ScrapeWorker(
+            url,
+            self.css,
+            self.folder,
+            use_alt_json=self.rename_enabled,
+        )
         self.worker.progress.connect(self.update_progress)
         self.worker.finished.connect(self.scrape_finished)
         self.worker.start()

--- a/MOTEUR/scraping/widgets/scrap_widget.py
+++ b/MOTEUR/scraping/widgets/scrap_widget.py
@@ -26,6 +26,8 @@ class ScrapWidget(QWidget):
         self.woo_widget = WooImageURLWidget()
         self.compare_widget = VariantComparisonWidget()
         self.combined_widget = CombinedScrapeWidget()
+        self.rename_enabled = True
+        self.combined_widget.set_rename_enabled(self.rename_enabled)
 
         self.modules_order = [
             "Images",
@@ -67,3 +69,9 @@ class ScrapWidget(QWidget):
             self.tabs.insertTab(pos, widget, name)
         elif not enabled and current_index != -1:
             self.tabs.removeTab(current_index)
+
+    # ------------------------------------------------------------------
+    def set_rename(self, enabled: bool) -> None:
+        """Propagate rename setting to sub-widgets."""
+        self.rename_enabled = enabled
+        self.combined_widget.set_rename_enabled(enabled)

--- a/MOTEUR/scraping/widgets/settings_widget.py
+++ b/MOTEUR/scraping/widgets/settings_widget.py
@@ -10,6 +10,7 @@ class ScrapingSettingsWidget(QWidget):
     """Tab allowing to enable or disable scraping modules."""
 
     module_toggled = Signal(str, bool)
+    rename_toggled = Signal(bool)
 
     def __init__(self, modules: Iterable[str], parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -21,5 +22,10 @@ class ScrapingSettingsWidget(QWidget):
             cb.toggled.connect(lambda state, n=name: self.module_toggled.emit(n, state))
             layout.addWidget(cb)
             self.checkboxes[name] = cb
+
+        self.rename_cb = QCheckBox("Renomage")
+        self.rename_cb.setChecked(True)
+        self.rename_cb.toggled.connect(self.rename_toggled)
+        layout.addWidget(self.rename_cb)
 
         layout.addStretch()

--- a/main.py
+++ b/main.py
@@ -324,6 +324,9 @@ class MainWindow(QMainWindow):
         self.scraping_settings_page.module_toggled.connect(
             self.scrap_page.toggle_module
         )
+        self.scraping_settings_page.rename_toggled.connect(
+            self.scrap_page.set_rename
+        )
         self.stack.addWidget(self.scraping_settings_page)
 
         self.profile_page.profile_chosen.connect(

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -41,6 +41,7 @@ def test_default_profile_creation(tmp_path: Path) -> None:
             "domain": "https://www.planetebob.fr",
             "date": "2025/07",
             "url_file": "",
+            "rename": True,
         }
     }
 


### PR DESCRIPTION
## Summary
- add "Renomage" option in scraping settings
- propagate rename setting to ScrapWidget and CombinedScrapeWidget
- store rename preference in profiles
- test updates for profile manager

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_687fe2abd1cc83309f18307ce2e42894