### PR TITLE
Implement filename cleanup for variant images

### DIFF
--- a/MOTEUR/scraping/image_scraper/scraper.py
+++ b/MOTEUR/scraping/image_scraper/scraper.py
@@ -135,6 +135,7 @@ def download_images(
             folder = _safe_folder(title, parent_dir)
             for idx, img_url in enumerate(mapping.values(), start=1):
                 filename = os.path.basename(img_url.split("?")[0])
+                filename = re.sub(r"-\d+(?=\.\w+$)", "", filename)
                 path = dl_helpers.unique_path(folder, filename, reserved_paths)
                 try:
                     dl_helpers.download_binary(img_url, path, ua)


### PR DESCRIPTION
## Summary
- strip trailing numeric suffixes from filenames when downloading variant images

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fec5da2288330bac025e186c3e8ac