### PR TITLE
Add carousel support for image scraping

### DIFF
--- a/MOTEUR/scraping/widgets/combined_scrape_widget.py
+++ b/MOTEUR/scraping/widgets/combined_scrape_widget.py
@@ -215,11 +215,16 @@ class CombinedScrapeWidget(QWidget):
         url = self.pending_urls.pop(0)
         self.current_url = url
         self.console.append(url)
+        parts = self.css.split()
+        carousel = None
+        if parts and parts[-1].startswith("img"):
+            carousel = " ".join(parts[:-1]) or None
         self.worker = ScrapeWorker(
             url,
             self.css,
             self.folder,
             use_alt_json=self.rename_enabled,
+            carousel_selector=carousel,
         )
         self.worker.progress.connect(self.update_progress)
         self.worker.finished.connect(self.scrape_finished)


### PR DESCRIPTION
## Summary
- allow ScrapeWorker to pass a carousel selector
- derive carousel selector from CSS in widgets

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c395ae048330b5fa8de59b816e4c